### PR TITLE
Add missing reinterpret methods

### DIFF
--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -19,6 +19,12 @@ const UF = (Ufixed8, Ufixed10, Ufixed12, Ufixed14, Ufixed16)
   rawtype{T,f}(::Type{UfixedBase{T,f}}) = T
 nbitsfrac{T,f}(::Type{UfixedBase{T,f}}) = f
 
+reinterpret(::Type{Ufixed8}, x::Uint8) = UfixedBase{Uint8,8}(x,0)
+for (T,f) in ((Ufixed10,10),(Ufixed12,12),(Ufixed14,14),(Ufixed16,16))
+    @eval reinterpret(::Type{$T}, x::Uint16) = UfixedBase{Uint16,$f}(x, 0)
+end
+
+
 # The next lines mimic the floating-point literal syntax "3.2f0"
 immutable UfixedConstructor{T,f} end
 *{T,f}(n::Integer, ::UfixedConstructor{T,f}) = UfixedBase{T,f}(n,0)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -6,6 +6,12 @@ using FixedPointNumbers, Base.Test
 @test reinterpret(0xa2uf14) == 0xa2
 @test reinterpret(0xa2uf16) == 0xa2
 
+@test reinterpret(Ufixed8, 0xa2) == 0xa2uf8
+@test reinterpret(Ufixed10, 0x1fa2) == 0x1fa2uf10
+@test reinterpret(Ufixed12, 0x1fa2) == 0x1fa2uf12
+@test reinterpret(Ufixed14, 0x1fa2) == 0x1fa2uf14
+@test reinterpret(Ufixed16, 0x1fa2) == 0x1fa2uf16
+
 for T in FixedPointNumbers.UF
     @test zero(T) == 0
     @test one(T) == 1


### PR DESCRIPTION
Since I suspect you don't do this much, a little cheat-sheet (apologies if this is all obvious to you): after merging, do

```
Pkg.checkout("FixedPointNumbers")
Pkg.update()
Pkg.tag("FixedPointNumbers")
Pkg.publish()
```

and that will bump the patch version for all users.

In my own packages I don't do this for every commit that comes in, but I'm not envisioning a whole stream of these FixedPointNumbers changes (but, who knows...still trying to finish migrating Images to use this).
