### PR TITLE
Fix show for Ufixed

### DIFF
--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -163,3 +163,4 @@ end
 showcompact{T,f}(io::IO, x::UfixedBase{T,f}) = show(io, round(convert(Float64,x), iceil(f/_log2_10)))
 
 show{T,f}(io::IO, ::Type{UfixedBase{T,f}}) = print(io, "Ufixed", f)
+showcompact{T,f}(io::IO, ::Type{UfixedBase{T,f}}) = print(io, "Ufixed", f)


### PR DESCRIPTION
This fixes a bug that cropped up in the display of methods written in terms of `T<:Ufixed`. Since you can't call `nbitsfrac` on a `Ufixed` (it needs to be a `UfixedBase`), it triggered an error.
