### PR TITLE
Delete specialized show methods for types

### DIFF
--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -161,6 +161,3 @@ function show{T,f}(io::IO, x::UfixedBase{T,f})
     print(io, ")")
 end
 showcompact{T,f}(io::IO, x::UfixedBase{T,f}) = show(io, round(convert(Float64,x), iceil(f/_log2_10)))
-
-show{T,f}(io::IO, ::Type{UfixedBase{T,f}}) = print(io, "Ufixed", f)
-showcompact{T,f}(io::IO, ::Type{UfixedBase{T,f}}) = print(io, "Ufixed", f)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -104,9 +104,6 @@ end
 # Show
 x = 0xaauf8
 iob = IOBuffer()
-show(iob, typeof(x))
-@test takebuf_string(iob) == "Ufixed8"
-
 show(iob, x)
 str = takebuf_string(iob)
 @test beginswith(str, "Ufixed8(")


### PR DESCRIPTION
Earlier incarnations caused troubles, and it was recommended (see issue #9)
to drop these.

See also https://github.com/JuliaLang/Color.jl/commit/fc94af256616509eeea881ad381462aa1af92a49
