### PR TITLE
Use widening with addition and subtraction

### DIFF
--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -78,9 +78,8 @@ eps{T<:Ufixed}(::T) = eps(T)
 sizeof{T<:Ufixed}(::Type{T}) = sizeof(rawtype(T))
 
 # Arithmetic
-# Ufixed types are closed under addition and subtraction
-+{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = UfixedBase{T,f}(convert(T, reinterpret(x)+reinterpret(y)),0)
--{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = UfixedBase{T,f}(convert(T, reinterpret(x)-reinterpret(y)),0)
++{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = float32(x)+float32(y) # UfixedBase{T,f}(convert(T, reinterpret(x)+reinterpret(y)),0)
+-{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = float32(x)-float32(y) # UfixedBase{T,f}(convert(T, reinterpret(x)-reinterpret(y)),0)
 *{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = float32(x)*float32(y)
 /(x::Ufixed, y::Ufixed) = float32(x)/float32(y)
 
@@ -98,8 +97,8 @@ for T in UF
     k = 8*sizeof(R)-f
     ceilmask  = (typemax(R)<<k)>>k
     @eval begin
-        round(x::$T) = (y = trunc(x); return reinterpret(x-y)&$roundmask>0 ? y+one($T) : y)
-         ceil(x::$T) = (y = trunc(x); return reinterpret(x-y)&$ceilmask >0 ? y+one($T) : y)
+        round(x::$T) = (y = trunc(x); return convert(rawtype($T), reinterpret(x)-reinterpret(y))&$roundmask>0 ? $T(y+one($T)) : y)
+         ceil(x::$T) = (y = trunc(x); return convert(rawtype($T), reinterpret(x)-reinterpret(y))&$ceilmask >0 ? $T(y+one($T)) : y)
     end
 end
 

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -60,8 +60,8 @@ for T in FixedPointNumbers.UF
     @test y > x
     @test y != x
     @test x+y == T(0x35,0)
-    @test (x+y) - x == y
-    @test (x-y) + y == x
+    @test_approx_eq((x+y)-x, float32(y))
+    @test_approx_eq((x-y)+y, float32(x))
     @test x*y == float32(x)*float32(y)
     @test x/y == float32(x)/float32(y)
     @test x^2 == float32(x)^2
@@ -93,7 +93,7 @@ function testtrunc{T}(inc::T)
             println("Failed on x = ", x, ", xf = ", xf)
             rethrow(err)
         end
-        x += inc
+        x = convert(T, x+inc)
     end
 end
 


### PR DESCRIPTION
The original design decision was made in part to anticipate changes
Julia 0.4. Unfortunately, this runs into major trouble with
reductions. Since we need a package that works on 0.3, these changes
seem necessary. Once someone implements widening in the reduction functions
for 0.4, this change can probably be reverted (on the `julia 0.4-` branch of this package).
