### PR TITLE
Removed iround, iceil, itrunc etc.

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -1,9 +1,11 @@
 module FixedPointNumbers
 
+using Compat
+
 import Base: convert, promote_rule, show, showcompact, isinteger, abs, decompose,
              isnan, isinf, isfinite,
              zero, one, typemin, typemax, realmin, realmax, eps, sizeof, reinterpret,
-             trunc, round, floor, ceil, itrunc, iround, ifloor, iceil, bswap,
+             trunc, round, floor, ceil, bswap,
              div, fld, rem, mod, mod1, rem1, fld1, min, max,
              start, next, done
 

--- a/src/fixed32.jl
+++ b/src/fixed32.jl
@@ -39,7 +39,7 @@ abs{f}(x::Fixed32{f}) = Fixed32{f}(abs(x.i),0)
 
 # conversions and promotions
 convert{f}(::Type{Fixed32{f}}, x::Integer) = Fixed32{f}(x<<f,0)
-convert{f}(::Type{Fixed32{f}}, x::FloatingPoint) = Fixed32{f}(itrunc(x)<<f + int32(rem(x,1)*(1<<f)),0)
+convert{f}(::Type{Fixed32{f}}, x::FloatingPoint) = Fixed32{f}(trunc(Int32,x)<<f + int32(rem(x,1)*(1<<f)),0)
 convert{f}(::Type{Fixed32{f}}, x::Rational) = Fixed32{f}(x.num)/Fixed32{f}(x.den)
 
 convert{f}(::Type{BigFloat}, x::Fixed32{f}) =
@@ -70,4 +70,4 @@ function show(io::IO, x::Fixed32)
     print(io, ")")
 end
 const _log2_10 = 3.321928094887362
-showcompact{f}(io::IO, x::Fixed32{f}) = show(io, round(convert(Float64,x), iceil(f/_log2_10)))
+showcompact{f}(io::IO, x::Fixed32{f}) = show(io, round(convert(Float64,x), ceil(Int,f/_log2_10)))

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -47,9 +47,9 @@ rawone(v) = reinterpret(one(v))
 
 # Conversions
 convert{T<:Ufixed}(::Type{T}, x::T)    = x
-convert{T1<:Ufixed,}(::Type{T1}, x::Ufixed)  = reinterpret(T1, iround(rawtype(T1), (rawone(T1)/rawone(T2))*reinterpret(x)))
+convert{T1<:Ufixed,}(::Type{T1}, x::Ufixed)  = reinterpret(T1, round(rawtype(T1), (rawone(T1)/rawone(T2))*reinterpret(x)))
 convert(::Type{Ufixed16}, x::Ufixed8)  = reinterpret(Ufixed16, convert(Uint16, 0x0101*reinterpret(x)))
-convert{T<:Ufixed}(::Type{T}, x::Real) = T(iround(rawtype(T), rawone(T)*x),0)
+convert{T<:Ufixed}(::Type{T}, x::Real) = T(round(rawtype(T), rawone(T)*x),0)
 
 ufixed8(x)  = convert(Ufixed8, x)
 ufixed10(x) = convert(Ufixed10, x)
@@ -106,14 +106,14 @@ for T in UF
     end
 end
 
-itrunc{T<:Integer}(::Type{T}, x::Ufixed) = convert(T, div(reinterpret(x), rawone(x)))
-iround{T<:Integer}(::Type{T}, x::Ufixed) = iround(T, reinterpret(x)/rawone(x))
-ifloor{T<:Integer}(::Type{T}, x::Ufixed) = itrunc(T, x)
- iceil{T<:Integer}(::Type{T}, x::Ufixed) =  iceil(T, reinterpret(x)/rawone(x))
-itrunc(x::Ufixed) = itrunc(Int, x)
-iround(x::Ufixed) = iround(Int, x)
-ifloor(x::Ufixed) = ifloor(Int, x)
- iceil(x::Ufixed) =  iceil(Int, x)
+trunc{T<:Integer}(::Type{T}, x::Ufixed) = convert(T, div(reinterpret(x), rawone(x)))
+round{T<:Integer}(::Type{T}, x::Ufixed) = round(T, reinterpret(x)/rawone(x))
+floor{T<:Integer}(::Type{T}, x::Ufixed) = trunc(T, x)
+ ceil{T<:Integer}(::Type{T}, x::Ufixed) =  ceil(T, reinterpret(x)/rawone(x))
+trunc(x::Ufixed) = trunc(Int, x)
+round(x::Ufixed) = round(Int, x)
+floor(x::Ufixed) = floor(Int, x)
+ ceil(x::Ufixed) =  ceil(Int, x)
 
 isfinite(x::Ufixed) = true
 isnan(x::Ufixed) = false
@@ -172,4 +172,4 @@ function show{T,f}(io::IO, x::UfixedBase{T,f})
     showcompact(io, x)
     print(io, ")")
 end
-showcompact{T,f}(io::IO, x::UfixedBase{T,f}) = show(io, round(convert(Float64,x), iceil(f/_log2_10)))
+showcompact{T,f}(io::IO, x::UfixedBase{T,f}) = show(io, round(convert(Float64,x), ceil(Int,f/_log2_10)))

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -88,11 +88,11 @@ function testtrunc{T}(inc::T)
                 @test ceil(x) == ceil(xf)
             end
             @test floor(x) == floor(xf)
-            @test itrunc(x) == itrunc(xf)
-            @test iround(x) == iround(xf)
-            @test ifloor(x) == ifloor(xf)
+            @test trunc(Int,x) == trunc(Int,xf)
+            @test round(Int,x) == round(Int,xf)
+            @test floor(Int,x) == floor(Int,xf)
             if cxf < tm
-                @test iceil(x) == iceil(xf)
+                @test ceil(Int,x) == ceil(Int,xf)
             end
         catch err
             println("Failed on x = ", x, ", xf = ", xf)


### PR DESCRIPTION
Hi, after pulling from Julia  master ProfileView I started getting deprecation messages about iround and similar functions.  Going down the rabbit hole I managed to fix it with this commit.  The tests pass but I have no idea how FixedPointNumbers work so you should definitely check whether I didn't break anything.

EDIT: Tests fail for juliareleases, I guess this might be a problem.
