### PR TITLE
Implement promotion among UFixed, make convert errors more informative

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -109,4 +109,13 @@ end
 const _log2_10 = 3.321928094887362
 showcompact{T,f}(io::IO, x::FixedPoint{T,f}) = show(io, round(convert(Float64,x), ceil(Int,f/_log2_10)))
 
+@noinline function throw_converterror{T<:FixedPoint}(::Type{T}, x)
+    n = 2^(8*sizeof(T))
+    bitstring = sizeof(T) == 1 ? "an 8-bit" : "a $(8*sizeof(T))-bit"
+    io = IOBuffer()
+    showcompact(io, typemin(T)); Tmin = takebuf_string(io)
+    showcompact(io, typemax(T)); Tmax = takebuf_string(io)
+    throw(ArgumentError("$T is $bitstring type representing $n values from $Tmin to $Tmax; cannot represent $x"))
+end
+
 end # module

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -151,3 +151,15 @@ promote_rule{T<:UFixed, R<:Rational}(::Type{T}, ::Type{R}) = R
     Tp = eps(convert(Float32, typemax(Ti))) > eps(T) ? Float64 : Float32
     :( $Tp )
 end
+@generated function promote_rule{T1,T2,f1,f2}(::Type{UFixed{T1,f1}}, ::Type{UFixed{T2,f2}})
+    f = max(f1, f2)  # ensure we have enough precision
+    T = promote_type(T1, T2)
+    # make sure we have enough integer bits
+    i1, i2 = 8*sizeof(T1)-f1, 8*sizeof(T2)-f2  # number of integer bits for each
+    i = 8*sizeof(T)-f
+    while i < max(i1, i2)
+        T = widen1(T)
+        i = 8*sizeof(T)-f
+    end
+    :(UFixed{$T,$f})
+end

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -79,7 +79,7 @@ abs(x::UFixed) = x
 
 # Comparisons
  <{T<:UFixed}(x::T, y::T) = reinterpret(x) < reinterpret(y)
-<={T<:UFixed}(x::T, y::T) = reinterpret(x) < reinterpret(y)
+<={T<:UFixed}(x::T, y::T) = reinterpret(x) <= reinterpret(y)
 
 # Functions
 trunc{T<:UFixed}(x::T) = T(div(reinterpret(x), rawone(T))*rawone(T),0)

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -50,6 +50,7 @@ _convert{U<:UFixed  }(::Type{U}, ::Type{UInt128}, x) = U(round(UInt128, rawone(U
 rem{T<:UFixed}(x::T, ::Type{T}) = x
 rem{T<:UFixed}(x::UFixed, ::Type{T}) = reinterpret(T, unsafe_trunc(rawtype(T), round((rawone(T)/rawone(x))*reinterpret(x))))
 rem{T<:UFixed}(x::Real, ::Type{T}) = reinterpret(T, unsafe_trunc(rawtype(T), round(rawone(T)*x)))
+rem{T<:UFixed}(x::Integer, ::Type{T}) = reinterpret(T, (rawone(T)*x) % rawtype(T))  # can be deleted once unsafe_trunc supports integer types (julia #18629)
 
 convert(::Type{BigFloat}, x::UFixed) = reinterpret(x)*(1/BigFloat(rawone(x)))
 function convert{T<:AbstractFloat}(::Type{T}, x::UFixed)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -169,6 +169,14 @@ end
 r = 1uf8:1uf8:48uf8
 @test length(r) == 48
 
+# Promotion within UFixed
+@test @inferred(promote(UFixed8(0.2), UFixed8(0.8))) ===
+    (UFixed8(0.2), UFixed8(0.8))
+@test @inferred(promote(UFixed{UInt16,3}(0.2), UFixed{UInt8,3}(0.86))) ===
+    (UFixed{UInt16,3}(0.2), UFixed{UInt16,3}(0.86))
+@test @inferred(promote(UFixed{UInt8,7}(0.197), UFixed{UInt8,4}(0.8))) ===
+    (UFixed{UInt16,7}(0.197), UFixed{UInt16,7}(0.8))
+
 # Show
 x = 0xaauf8
 iob = IOBuffer()

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -93,6 +93,9 @@ end
 @test (65.2 % UFixed10).i == round(Int, 65.2*1023) % UInt16
 @test (-0.3 % UFixed10).i == round(Int, -0.3*1023) % UInt16
 
+@test 1 % UFixed8 == 1
+@test 2 % UFixed8 == UFixed8(0.996)
+
 x = UFixed8(0b01010001, 0)
 @test ~x == UFixed8(0b10101110, 0)
 @test -x == 0xafuf8

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -65,7 +65,7 @@ x = UFixed8(0.5)
 @test convert(UFixed14, 1.1/typemax(UInt16)*4)  == eps(UFixed14)
 @test convert(UFixed16, 1.1/typemax(UInt16))    == eps(UFixed16)
 @test convert(UFixed{UInt32,16}, 1.1/typemax(UInt32)*2^16) == eps(UFixed{UInt32,16})
-@test convert(UFixed{UInt64,3},  1.1/typemax(UInt64)*2^61)  == eps(UFixed{UInt64,3})
+@test convert(UFixed{UInt64,3},  1.1/typemax(UInt64)*UInt64(2)^61)  == eps(UFixed{UInt64,3})
 @test convert(UFixed{UInt128,7}, 1.1/typemax(UInt128)*UInt128(2)^121) == eps(UFixed{UInt128,7})
 
 @test convert(UFixed8,  1.1f0/typemax(UInt8)) == eps(UFixed8)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -44,14 +44,15 @@ end
 @test typemax(UFixed{UInt64,3}) == typemax(UInt64) // (2^3-1)
 @test typemax(UFixed{UInt128,7}) == typemax(UInt128) // (2^7-1)
 
-@test_throws InexactError UFixed8(2)
-@test_throws InexactError UFixed8(255)
-@test_throws InexactError UFixed8(0xff)
-@test_throws InexactError UFixed16(2)
-@test_throws InexactError UFixed16(0xff)
-@test_throws InexactError UFixed16(0xffff)
-@test_throws InexactError convert(UFixed8,  typemax(UFixed10))
-@test_throws InexactError convert(UFixed16, typemax(UFixed10))
+# TODO: change back to InexactError when it allows message strings
+@test_throws ArgumentError UFixed8(2)
+@test_throws ArgumentError UFixed8(255)
+@test_throws ArgumentError UFixed8(0xff)
+@test_throws ArgumentError UFixed16(2)
+@test_throws ArgumentError UFixed16(0xff)
+@test_throws ArgumentError UFixed16(0xffff)
+@test_throws ArgumentError convert(UFixed8,  typemax(UFixed10))
+@test_throws ArgumentError convert(UFixed16, typemax(UFixed10))
 
 x = UFixed8(0.5)
 @test isfinite(x) == true

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -21,7 +21,7 @@ v = @compat UFixed12.([2])
 @test v == UFixed12[0x1ffeuf12]
 @test isa(v, Vector{UFixed12})
 
-UF2 = (UFixed{UInt32,16}, UFixed{UInt64,3}, UFixed{UInt128,7})
+UF2 = (UFixed{UInt32,16}, UFixed{UInt64,3}, UFixed{UInt64,51}, UFixed{UInt128,7}, UFixed{UInt128,51})
 
 for T in (FixedPointNumbers.UF..., UF2...)
     @test zero(T) == 0
@@ -43,6 +43,7 @@ end
 @test typemax(UFixed{UInt32,16}) == typemax(UInt32) // (2^16-1)
 @test typemax(UFixed{UInt64,3}) == typemax(UInt64) // (2^3-1)
 @test typemax(UFixed{UInt128,7}) == typemax(UInt128) // (2^7-1)
+@test typemax(UFixed{UInt128,100}) == typemax(UInt128) // (UInt128(2)^100-1)
 
 # TODO: change back to InexactError when it allows message strings
 @test_throws ArgumentError UFixed8(2)
@@ -53,6 +54,8 @@ end
 @test_throws ArgumentError UFixed16(0xffff)
 @test_throws ArgumentError convert(UFixed8,  typemax(UFixed10))
 @test_throws ArgumentError convert(UFixed16, typemax(UFixed10))
+@test_throws ArgumentError convert(UFixed{UInt128,100}, 10^9)
+@test_throws ArgumentError convert(UFixed{UInt128,100}, 10.0^9)
 
 x = UFixed8(0.5)
 @test isfinite(x) == true
@@ -104,8 +107,8 @@ x = UFixed8(0b01010001, 0)
 for T in (FixedPointNumbers.UF..., UF2...)
     x = T(0x10,0)
     y = T(0x25,0)
-    fx = convert(Float32, x)
-    fy = convert(Float32, y)
+    fx = convert(FixedPointNumbers.floattype(T), x)
+    fy = convert(FixedPointNumbers.floattype(T), y)
     @test y > x
     @test y != x
     @test typeof(x+y) == T

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -157,6 +157,9 @@ for T in (FixedPointNumbers.UF..., UF2...)
     testtrunc(eps(T))
 end
 
+@test !(UFixed8(0.5) < UFixed8(0.5))
+@test UFixed8(0.5) <= UFixed8(0.5)
+
 @test div(0x10uf8, 0x02uf8) == fld(0x10uf8, 0x02uf8) == 8
 @test div(0x0fuf8, 0x02uf8) == fld(0x0fuf8, 0x02uf8) == 7
 @test Base.fld1(0x10uf8, 0x02uf8) == 8


### PR DESCRIPTION
On the master branch, we have the following bug:
```jl
julia> UFixed8(0.5) < UFixed16(0.8)
ERROR: no promotion exists for FixedPointNumbers.UFixed{UInt8,8} and FixedPointNumbers.UFixed{UInt16,16}
 in promote(::FixedPointNumbers.UFixed{UInt8,8}, ::FixedPointNumbers.UFixed{UInt16,16}) at ./promotion.jl:153
 in <(::FixedPointNumbers.UFixed{UInt8,8}, ::FixedPointNumbers.UFixed{UInt16,16}) at ./promotion.jl:204
```

We also have this uninformative message:
```jl
julia> convert(UFixed8, 1.2)
ERROR: InexactError()
 in trunc(::Type{UInt8}, ::Float64) at ./float.jl:458
 in _convert at /home/tim/.julia/v0.5/FixedPointNumbers/src/ufixed.jl:47 [inlined]
 in convert(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Float64) at /home/tim/.julia/v0.5/FixedPointNumbers/src/ufixed.jl:46
```

This PR fixes the bug by implementing `promote_type` among `UFixed` types. It also produces the more verbose error message:
```jl
julia> convert(UFixed8, 1.2)
ERROR: ArgumentError: FixedPointNumbers.UFixed{UInt8,8} is an 8-bit type representing 256 values from 0.0 to 1.0; cannot represent 1.2
 in throw_converterror(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Float64) at /home/tim/.julia/v0.5/FixedPointNumbers/src/FixedPointNumbers.jl:118
 in _convert(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Type{UInt8}, ::Float64) at /home/tim/.julia/v0.5/FixedPointNumbers/src/ufixed.jl:53
 in convert(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Float64) at /home/tim/.julia/v0.5/FixedPointNumbers/src/ufixed.jl:50
```

Assuming people like this, I think it should be merged before #51, and we can tag a new version before making a more incompatible change.