### PR TITLE
Turn on coverage-testing for Julia 0.6, add README badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ notifications:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("FixedPointNumbers")'
-    - julia -e 'cd(Pkg.dir("FixedPointNumbers", "test")); include("runtests.jl")'
+    - julia -e 'if VERSION >= v"0.6.0-dev.565" Pkg.test("FixedPointNumbers"; coverage=true); else cd(Pkg.dir("FixedPointNumbers", "test")); include("runtests.jl"); end '
+after_success:
+  # push coverage results to Codecov
+  - julia -e 'if VERSION >= v"0.6.0-dev.565" cd(Pkg.dir("FixedPointNumbers")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder()); end'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # FixedPointNumbers
 
-This library exports fixed-point number types.  A
+[![Build Status](https://travis-ci.org/JuliaMath/FixedPointNumbers.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/FixedPointNumbers.jl)
+
+[![codecov.io](http://codecov.io/github/JuliaMath/FixedPointNumbers.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaMath/FixedPointNumbers.jl?branch=master)
+
+This library implements fixed-point number types.  A
 [fixed-point number][wikipedia] represents a fractional, or
 non-integral, number.  In contrast with the more widely known
 floating-point numbers, with fixed-point numbers the decimal point

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -11,7 +11,6 @@ end
   rawtype{T,f}(::Type{UFixed{T,f}}) = T
   rawtype(x::Number) = rawtype(typeof(x))
 nbitsfrac{T,f}(::Type{UFixed{T,f}}) = f
-nbitsfrac(x::Number) = nbitsfract(typeof(x))
 
 typealias UFixed8  UFixed{UInt8,8}
 typealias UFixed10 UFixed{UInt16,10}

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -41,10 +41,12 @@ rawone(v) = reinterpret(one(v))
 
 # Conversions
 convert{T<:UFixed}(::Type{T}, x::T) = x
-function convert{T<:UFixed}(::Type{T}, x::UFixed)
-    y = round((rawone(T)/rawone(x))*reinterpret(x))
-    (0 <= y) & (y <= typemax(rawtype(T))) || throw_converterror(T, x)
-    reinterpret(T, _unsafe_trunc(rawtype(T), y))
+convert{T1,T2,f}(::Type{UFixed{T1,f}}, x::UFixed{T2,f}) = UFixed{T1,f}(convert(T1, x.i), 0)
+function convert{T,f}(::Type{UFixed{T,f}}, x::UFixed)
+    U = UFixed{T,f}
+    y = round((rawone(U)/rawone(x))*reinterpret(x))
+    (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)
+    reinterpret(U, _unsafe_trunc(T, y))
 end
 convert(::Type{UFixed16}, x::UFixed8) = reinterpret(UFixed16, convert(UInt16, 0x0101*reinterpret(x)))
 convert{U<:UFixed}(::Type{U}, x::Real) = _convert(U, rawtype(U), x)

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -144,14 +144,11 @@ end
 # Iteration
 # The main subtlety here is that iterating over 0x00uf8:0xffuf8 will wrap around
 # unless we iterate using a wider type
-if VERSION < v"0.3-"
-    start{T<:UFixed}(r::Range{T}) = convert(typeof(reinterpret(r.start)+reinterpret(r.step)), reinterpret(r.start))
-    next{T<:UFixed}(r::Range{T}, i::Integer) = (T(i,0), i+reinterpret(r.step))
-    done{T<:UFixed}(r::Range{T}, i::Integer) = isempty(r) || (i > r.len)
-else
-    start{T<:UFixed}(r::StepRange{T}) = convert(typeof(reinterpret(r.start)+reinterpret(r.step)), reinterpret(r.start))
-    next{T<:UFixed}(r::StepRange{T}, i::Integer) = (T(i,0), i+reinterpret(r.step))
-    done{T<:UFixed}(r::StepRange{T}, i::Integer) = isempty(r) || (i > reinterpret(r.stop))
+@inline start{T<:UFixed}(r::StepRange{T}) = widen1(reinterpret(r.start))
+@inline next{T<:UFixed}(r::StepRange{T}, i::Integer) = (T(i,0), i+reinterpret(r.step))
+@inline function done{T<:UFixed}(r::StepRange{T}, i::Integer)
+    i1, i2 = reinterpret(r.start), reinterpret(r.stop)
+    isempty(r) | (i < min(i1, i2)) | (i > max(i1, i2))
 end
 
 function decompose(x::UFixed)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -84,6 +84,12 @@ for T in (FixedPointNumbers.UF..., UF2...)
     @test convert(Rational, one(T)) == 1
 end
 @test convert(Rational, convert(UFixed8, 0.5)) == 0x80//0xff
+@test convert(UFixed16, one(UFixed8)) === one(UFixed16)
+@test convert(UFixed16, UFixed8(0.5)).i === 0x8080
+
+@test  UFixed8(0.2) % UFixed8  === UFixed8(0.2)
+@test UFixed14(1.2) % UFixed16 === UFixed16(0.20002)
+@test UFixed14(1.2) % UFixed8  === UFixed8(0.196)
 
 for i = 0.0:0.1:1.0
     @test i % UFixed8 === UFixed8(i)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -86,6 +86,7 @@ end
 @test convert(Rational, convert(UFixed8, 0.5)) == 0x80//0xff
 @test convert(UFixed16, one(UFixed8)) === one(UFixed16)
 @test convert(UFixed16, UFixed8(0.5)).i === 0x8080
+@test convert(UFixed{UInt16,7}, UFixed{UInt8,7}(0.504)) === UFixed{UInt16,7}(0.504)
 
 @test  UFixed8(0.2) % UFixed8  === UFixed8(0.2)
 @test UFixed14(1.2) % UFixed16 === UFixed16(0.20002)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -176,6 +176,12 @@ end
 r = 1uf8:1uf8:48uf8
 @test length(r) == 48
 
+counter = 0
+for x in UFixed8(0):eps(UFixed8):UFixed8(1)
+    counter += 1
+end
+@test counter == 256
+
 # Promotion within UFixed
 @test @inferred(promote(UFixed8(0.2), UFixed8(0.8))) ===
     (UFixed8(0.2), UFixed8(0.8))


### PR DESCRIPTION
We restrict to 0.6 because earlier versions of Julia could not obtain accurate coverage info without turning off inlining, and for this package inlining makes a big difference in the running time of the tests.