### PR TITLE
Improve consistency of promote

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -12,6 +12,14 @@ import Base: ==, <, <=, -, +, *, /, ~,
              div, fld, rem, mod, mod1, rem1, fld1, min, max, minmax,
              start, next, done, r_promote, reducedim_init
 
+if VERSION <= v"0.5.0-dev+755"
+    macro pure(ex)
+        nothing
+    end
+else
+    using Base: @pure
+end
+
 using Compat
 
 # T => BaseType

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,9 @@
+using FixedPointNumbers, Base.Test
+
+if VERSION >= v"0.5.0"
+    @test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))
+end
+
 for f in ["ufixed.jl", "fixed.jl"]
     println("Testing $f")
     include(f)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -197,6 +197,13 @@ end
 @test @inferred(promote(UFixed{UInt8,7}(0.197), UFixed{UInt8,4}(0.8))) ===
     (UFixed{UInt16,7}(0.197), UFixed{UInt16,7}(0.8))
 
+@test promote_type(UFixed8,Float32,Int) == Float32
+@test promote_type(UFixed8,Int,Float32) == Float32
+@test promote_type(Int,UFixed8,Float32) == Float32
+@test promote_type(Int,Float32,UFixed8) == Float32
+@test promote_type(Float32,Int,UFixed8) == Float32
+@test promote_type(Float32,UFixed8,Int) == Float32
+
 # Show
 x = 0xaauf8
 iob = IOBuffer()


### PR DESCRIPTION
It turned out that calling `promote_type` with arguments in different orders led to different results:
```jl
julia> promote_type(Float32, UFixed8, Int)
Float64

julia> promote_type(UFixed8, Float32, Int)
Float32
```
That seems like a bad thing.
