### PR TITLE
Centralize floating-point conversion and implement isapprox

### DIFF
--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -13,6 +13,7 @@ typealias Fixed16 Fixed{Int32, 16}
 
   rawtype{T,f}(::Type{Fixed{T,f}}) = T
 nbitsfrac{T,f}(::Type{Fixed{T,f}}) = f
+floattype{T<:Fixed}(::Type{T}) = floattype(supertype(T))
 
 # basic operators
 -{T,f}(x::Fixed{T,f}) = Fixed{T,f}(-x.i,0)
@@ -36,6 +37,9 @@ convert{T,f}(::Type{Fixed{T,f}}, x::Rational) = Fixed{T,f}(x.num)/Fixed{T,f}(x.d
 
 rem{T,f}(x::Integer, ::Type{Fixed{T,f}}) = Fixed{T,f}(rem(x,T)<<f,0)
 rem{T,f}(x::Real,    ::Type{Fixed{T,f}}) = Fixed{T,f}(rem(Integer(trunc(x)),T)<<f + rem(Integer(round(rem(x,1)*(1<<f))),T),0)
+
+# convert{T,f}(::Type{AbstractFloat}, x::Fixed{T,f}) = convert(floattype(x), x)
+float(x::Fixed) = convert(floattype(x), x)
 
 convert{T,f}(::Type{BigFloat}, x::Fixed{T,f}) =
     convert(BigFloat,x.i>>f) + convert(BigFloat,x.i&(1<<f - 1))/convert(BigFloat,1<<f)

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -80,9 +80,6 @@ convert{Ti<:Integer}(::Type{Rational{Ti}}, x::UFixed) = convert(Ti, reinterpret(
 convert(::Type{Rational}, x::UFixed) = reinterpret(x)//rawone(x)
 
 # Traits
-eps{T<:UFixed}(::Type{T}) = T(one(rawtype(T)),0)
-eps{T<:UFixed}(::T) = eps(T)
-sizeof{T<:UFixed}(::Type{T}) = sizeof(rawtype(T))
 abs(x::UFixed) = x
 
 (-){T<:UFixed}(x::T) = T(-reinterpret(x), 0)
@@ -126,16 +123,6 @@ isinf(x::UFixed) = false
 bswap{f}(x::UFixed{UInt8,f}) = x
 bswap(x::UFixed)  = typeof(x)(bswap(reinterpret(x)),0)
 
-for f in (:div, :fld, :fld1)
-    @eval begin
-        $f{T<:UFixed}(x::T, y::T) = $f(reinterpret(x),reinterpret(y))
-    end
-end
-for f in (:rem, :mod, :mod1, :rem1, :min, :max)
-    @eval begin
-        $f{T<:UFixed}(x::T, y::T) = T($f(reinterpret(x),reinterpret(y)),0)
-    end
-end
 function minmax{T<:UFixed}(x::T, y::T)
     a, b = minmax(reinterpret(x), reinterpret(y))
     T(a,0), T(b,0)

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -11,6 +11,7 @@ end
   rawtype{T,f}(::Type{UFixed{T,f}}) = T
   rawtype(x::Number) = rawtype(typeof(x))
 nbitsfrac{T,f}(::Type{UFixed{T,f}}) = f
+floattype{T<:UFixed}(::Type{T}) = floattype(supertype(T))
 
 typealias UFixed8  UFixed{UInt8,8}
 typealias UFixed10 UFixed{UInt16,10}
@@ -65,6 +66,9 @@ rem{T<:UFixed}(x::T, ::Type{T}) = x
 rem{T<:UFixed}(x::UFixed, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round((rawone(T)/rawone(x))*reinterpret(x))))
 rem{T<:UFixed}(x::Real, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round(rawone(T)*x)))
 
+# convert(::Type{AbstractFloat}, x::UFixed) = convert(floattype(x), x)
+float(x::UFixed) = convert(floattype(x), x)
+
 convert(::Type{BigFloat}, x::UFixed) = reinterpret(x)*(1/BigFloat(rawone(x)))
 function convert{T<:AbstractFloat}(::Type{T}, x::UFixed)
     y = reinterpret(x)*(one(rawtype(x))/convert(T, rawone(x)))
@@ -80,17 +84,6 @@ eps{T<:UFixed}(::Type{T}) = T(one(rawtype(T)),0)
 eps{T<:UFixed}(::T) = eps(T)
 sizeof{T<:UFixed}(::Type{T}) = sizeof(rawtype(T))
 abs(x::UFixed) = x
-
-# Arithmetic
-if VERSION <= v"0.5.0-dev+755"
-    @generated function floattype{T,f}(::Type{UFixed{T,f}})
-        f>22 ? :(Float64) : :(Float32)
-    end
-else
-    @pure function floattype{T,f}(::Type{UFixed{T,f}})
-        f>22 ? Float64 : Float32
-    end
-end
 
 (-){T<:UFixed}(x::T) = T(-reinterpret(x), 0)
 (~){T<:UFixed}(x::T) = T(~reinterpret(x), 0)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -78,6 +78,10 @@ end
 @test ( 65.2 % T).i == round(Int,  65.2*512) % Int16
 @test (-67.2 % T).i == round(Int, -67.2*512) % Int16
 
+for T in [Fixed{Int8,7}, Fixed{Int16,8}, Fixed{Int16,10}]
+    testapprox(T)  # defined in ufixed.jl
+end
+
 # reductions
 F8 = Fixed{Int8,8}
 a = F8[0.498, 0.1]

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -97,6 +97,11 @@ for T in (Float16, Float32, Float64, BigFloat)
     @test isa(y, T)
 end
 
+# Floating-point conversions
+@test isa(float(one(Fixed{Int8,6})),   Float32)
+@test isa(float(one(Fixed{Int32,18})), Float32)
+@test isa(float(one(Fixed{Int32,25})), Float64)
+
 # Show
 x = Fixed{Int32,3}(0.25)
 iob = IOBuffer()

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -172,6 +172,18 @@ for T in (FixedPointNumbers.UF..., UF2...)
     testtrunc(eps(T))
 end
 
+function testapprox{T}(::Type{T})
+    for x = typemin(T):eps(T):typemax(T)-eps(T)
+        y = x+eps(T)
+        @test x ≈ y
+        @test y ≈ x
+        @test !(x ≈ y+eps(T))
+    end
+end
+for T in FixedPointNumbers.UF
+    testapprox(T)
+end
+
 @test !(UFixed8(0.5) < UFixed8(0.5))
 @test UFixed8(0.5) <= UFixed8(0.5)
 

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -111,11 +111,15 @@ x = UFixed8(0b01010001, 0)
 @test ~x == UFixed8(0b10101110, 0)
 @test -x == 0xafuf8
 
+@test isa(float(one(UFixed{UInt8,7})),   Float32)
+@test isa(float(one(UFixed{UInt32,18})), Float32)
+@test isa(float(one(UFixed{UInt32,25})), Float64)
+
 for T in (FixedPointNumbers.UF..., UF2...)
     x = T(0x10,0)
     y = T(0x25,0)
-    fx = convert(FixedPointNumbers.floattype(T), x)
-    fy = convert(FixedPointNumbers.floattype(T), y)
+    fx = float(x)
+    fy = float(y)
     @test y > x
     @test y != x
     @test typeof(x+y) == T


### PR DESCRIPTION
This tries to be a little more consistent about *which* floating-point type (`Float32` or `Float64`) we use for conversions. As a consequence, this has the possibility of being breaking :frowning_face:, but I personally think it's worth it. I'll give others a chance to chime in before merging.

Also implemented `isapprox` so `x ≈ y` works nicely in tests (by default, allowing a 1-eps difference).