### PR TITLE
Don't use Float32 in printing

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -84,15 +84,10 @@ widen1(::Type{Int64})  = Int128
 widen1(::Type{UInt64}) = UInt128
 widen1(x::Integer) = x % widen1(typeof(x))
 
-if VERSION <= v"0.5.0-dev+755"
-    @generated function floattype{T,f}(::Type{FixedPoint{T,f}})
-        f>22 ? :(Float64) : :(Float32)
-    end
-else
-    @pure function floattype{T,f}(::Type{FixedPoint{T,f}})
-        f>22 ? Float64 : Float32
-    end
-end
+typealias ShortInts Union{Int8,UInt8,Int16,UInt16}
+
+floattype{T<:ShortInts,f}(::Type{FixedPoint{T,f}}) = Float32
+floattype{T,f}(::Type{FixedPoint{T,f}}) = Float64
 floattype(x::FixedPoint) = floattype(supertype(typeof(x)))
 
 

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -155,7 +155,7 @@ function show{T,f}(io::IO, x::FixedPoint{T,f})
     print(io, ")")
 end
 const _log2_10 = 3.321928094887362
-showcompact{T,f}(io::IO, x::FixedPoint{T,f}) = show(io, round(float(x), ceil(Int,f/_log2_10)))
+showcompact{T,f}(io::IO, x::FixedPoint{T,f}) = show(io, round(Float64(x), ceil(Int,f/_log2_10)))
 
 @noinline function throw_converterror{T<:FixedPoint}(::Type{T}, x)
     n = 2^(8*sizeof(T))

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -103,7 +103,7 @@ end
 
 # Floating-point conversions
 @test isa(float(one(Fixed{Int8,6})),   Float32)
-@test isa(float(one(Fixed{Int32,18})), Float32)
+@test isa(float(one(Fixed{Int32,18})), Float64)
 @test isa(float(one(Fixed{Int32,25})), Float64)
 
 # Show

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -112,7 +112,7 @@ x = UFixed8(0b01010001, 0)
 @test -x == 0xafuf8
 
 @test isa(float(one(UFixed{UInt8,7})),   Float32)
-@test isa(float(one(UFixed{UInt32,18})), Float32)
+@test isa(float(one(UFixed{UInt32,18})), Float64)
 @test isa(float(one(UFixed{UInt32,25})), Float64)
 
 for T in (FixedPointNumbers.UF..., UF2...)

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -234,8 +234,7 @@ x = 0xaauf8
 iob = IOBuffer()
 show(iob, x)
 str = takebuf_string(iob)
-@test startswith(str, "UFixed{UInt8,8}(")
-@test eval(parse(str)) == x
+@test str == "UFixed{UInt8,8}(0.667)"
 
 # scaledual
 function generic_scale!(C::AbstractArray, X::AbstractArray, s::Number)


### PR DESCRIPTION
Also tweaks the conversion to float again, but the last release is so new this should be OK (change only affects types like `UFixed{UInt32, 18}`, which is almost certainly not being used by anything).