### PR TITLE
WIP: 0.6 compatibility

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat 0.9.1
+Compat 0.9.5

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -21,6 +21,7 @@ else
 end
 
 using Compat
+import Compat.String
 
 # T => BaseType
 # f => Number of Bytes reserved for fractional part
@@ -83,6 +84,7 @@ widen1(::Type{Int32})  = Int64
 widen1(::Type{UInt32}) = UInt64
 widen1(::Type{Int64})  = Int128
 widen1(::Type{UInt64}) = UInt128
+widen1(::Type{UInt128}) = UInt128
 widen1(x::Integer) = x % widen1(typeof(x))
 
 typealias ShortInts Union{Int8,UInt8,Int16,UInt16}
@@ -157,8 +159,8 @@ scaledual{Tdual<:Number, T<:FixedPoint}(b::Tdual, x::Union{T,AbstractArray{T}}) 
     n = 2^(8*sizeof(T))
     bitstring = sizeof(T) == 1 ? "an 8-bit" : "a $(8*sizeof(T))-bit"
     io = IOBuffer()
-    showcompact(io, typemin(T)); Tmin = takebuf_string(io)
-    showcompact(io, typemax(T)); Tmax = takebuf_string(io)
+    showcompact(io, typemin(T)); Tmin = String(take!(io))
+    showcompact(io, typemax(T)); Tmax = String(take!(io))
     throw(ArgumentError("$T is $bitstring type representing $n values from $Tmin to $Tmax; cannot represent $x"))
 end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -41,7 +41,7 @@ function *{T,f}(n::Integer, ::NormedConstructor{T,f})
     i = 8*sizeof(T)-f
     io = IOBuffer()
     show(io, n)
-    nstr = takebuf_string(io)
+    nstr = String(take!(io))
     cstr = typeof(n) == T ? nstr : "convert($T, $nstr)"
     Base.depwarn("$(nstr)uf$f is deprecated, please use reinterpret(N$(i)f$f, $cstr) instead", :*)
     reinterpret(Normed{T,f}, convert(T, n))
@@ -54,4 +54,3 @@ const uf16 = NormedConstructor{UInt16,16}()
 
 @deprecate_binding UfixedConstructor NormedConstructor
 @deprecate_binding UFixedConstructor NormedConstructor
-

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -19,7 +19,7 @@ signbits{X<:Fixed}(::Type{X}) = 1
 
 for T in (Int8, Int16, Int32, Int64)
     for f in 0:sizeof(T)*8-1
-        sym = Symbol(takebuf_string(showtype(_iotypealias, Fixed{T,f})))
+        sym = Symbol(String(take!(showtype(_iotypealias, Fixed{T,f}))))
         @eval begin
             typealias $sym Fixed{$T,$f}
             export $sym

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -17,7 +17,7 @@ signbits{X<:Normed}(::Type{X}) = 0
 
 for T in (UInt8, UInt16, UInt32, UInt64)
     for f in 0:sizeof(T)*8
-        sym = Symbol(takebuf_string(showtype(_iotypealias, Normed{T,f})))
+        sym = Symbol(String(take!(showtype(_iotypealias, Normed{T,f}))))
         @eval begin
             typealias $sym Normed{$T,$f}
             export $sym
@@ -37,15 +37,17 @@ rawone(v) = reinterpret(one(v))
 
 # Conversions
 convert{T<:Normed}(::Type{T}, x::T) = x
-convert{T1,T2,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
-function convert{T,T2,f}(::Type{Normed{T,f}}, x::Normed{T2})
+convert{T1<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
+function convert{T<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T,f}}, x::Normed{T2})
     U = Normed{T,f}
     y = round((rawone(U)/rawone(x))*reinterpret(x))
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)
     reinterpret(U, _unsafe_trunc(T, y))
 end
-convert(::Type{N0f16}, x::N0f8) = reinterpret(N0f16, convert(UInt16, 0x0101*reinterpret(x)))
 convert{U<:Normed}(::Type{U}, x::Real) = _convert(U, rawtype(U), x)
+convert{T1,T2,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
+
+convert(::Type{N0f16}, x::N0f8) = reinterpret(N0f16, convert(UInt16, 0x0101*reinterpret(x)))
 function _convert{U<:Normed,T}(::Type{U}, ::Type{T}, x)
     y = round(widen1(rawone(U))*x)
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,5 +1,7 @@
 using Base.Test
 using FixedPointNumbers
+using Compat
+import Compat.String
 
 function test_op{F,T}(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol)
     # Make sure that the result is representable
@@ -50,8 +52,8 @@ function test_fixed{T}(::Type{T}, f)
     end
 end
 
-@test_approx_eq_eps convert(Fixed{Int8,7}, 0.8) 0.797 0.001
-@test_approx_eq_eps convert(Fixed{Int8,7}, 0.9) 0.898 0.001
+@test isapprox(convert(Fixed{Int8,7}, 0.8), 0.797, atol=0.001)
+@test isapprox(convert(Fixed{Int8,7}, 0.9), 0.898, atol=0.001)
 @test_throws InexactError convert(Fixed{Int8, 7}, 0.999)
 @test_throws InexactError convert(Fixed{Int8, 7}, 1.0)
 @test_throws InexactError convert(Fixed{Int8, 7}, 1)
@@ -110,7 +112,7 @@ end
 x = Fixed{Int32,5}(0.25)
 iob = IOBuffer()
 show(iob, x)
-str = takebuf_string(iob)
+str = String(take!(iob))
 @test str == "0.25Q26f5"
 @test eval(parse(str)) == x
 

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -1,6 +1,7 @@
 using FixedPointNumbers
 using Base.Test
 using Compat
+import Compat.String
 
 @test reinterpret(N0f8, 0xa2).i  === 0xa2
 @test reinterpret(N6f10, 0x1fa2).i === 0x1fa2
@@ -132,14 +133,14 @@ for T in (FixedPointNumbers.UF..., UF2...)
     @test typeof((x+y)-y) == T
     @test typeof(x*y) == T
     @test typeof(x/y) == T
-    @test_approx_eq(x+y, T(0x35,0))
-    @test_approx_eq((x+y)-x, fy)
-    @test_approx_eq((x-y)+y, fx)
-    @test_approx_eq(x*y, convert(T, fx*fy))
-    @test_approx_eq(x/y, convert(T, fx/fy))
-    @test_approx_eq(x^2, convert(T, fx^2))
-    @test_approx_eq(x^2.1f0, fx^2.1f0)
-    @test_approx_eq(x^2.1, convert(Float64, x)^2.1)
+    @test (x+y) ≈ T(0x35,0)
+    @test ((x+y)-x) ≈ fy
+    @test ((x-y)+y) ≈ fx
+    @test (x*y)  ≈ convert(T, fx*fy)
+    @test (x/y)  ≈ convert(T, fx/fy)
+    @test (x^2) ≈ convert(T, fx^2)
+    @test (x^2.1f0) ≈ fx^2.1f0
+    @test (x^2.1) ≈ convert(Float64, x)^2.1
 end
 
 function testtrunc{T}(inc::T)
@@ -239,7 +240,7 @@ end
 x = reinterpret(N0f8, 0xaa)
 iob = IOBuffer()
 show(iob, x)
-str = takebuf_string(iob)
+str = String(take!(iob))
 @test str == "0.667N0f8"
 @test eval(parse(str)) == x
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using FixedPointNumbers, Base.Test
 
-if VERSION >= v"0.5.0"
-    @test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))
-end
-
 for f in ["normed.jl", "fixed.jl"]
     println("Testing $f")
     include(f)
+end
+
+if v"0.5.0" <= VERSION < v"0.6.0-dev"
+    @test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))
 end


### PR DESCRIPTION
Untested on 0.5 and needs some cleanup probably

The `where` syntax doesn't work on v0.6.

this rebases #62 on top of #63 