### PR TITLE
Fix most of depwarn and error on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.9.1
+Compat 0.9.5

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -21,6 +21,7 @@ else
 end
 
 using Compat
+import Compat.String
 
 # T => BaseType
 # f => Number of Bytes reserved for fractional part
@@ -157,8 +158,8 @@ scaledual{Tdual<:Number, T<:FixedPoint}(b::Tdual, x::Union{T,AbstractArray{T}}) 
     n = 2^(8*sizeof(T))
     bitstring = sizeof(T) == 1 ? "an 8-bit" : "a $(8*sizeof(T))-bit"
     io = IOBuffer()
-    showcompact(io, typemin(T)); Tmin = takebuf_string(io)
-    showcompact(io, typemax(T)); Tmax = takebuf_string(io)
+    showcompact(io, typemin(T)); Tmin = String(take!(io))
+    showcompact(io, typemax(T)); Tmax = String(take!(io))
     throw(ArgumentError("$T is $bitstring type representing $n values from $Tmin to $Tmax; cannot represent $x"))
 end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -41,7 +41,7 @@ function *{T,f}(n::Integer, ::NormedConstructor{T,f})
     i = 8*sizeof(T)-f
     io = IOBuffer()
     show(io, n)
-    nstr = takebuf_string(io)
+    nstr = String(take!(io))
     cstr = typeof(n) == T ? nstr : "convert($T, $nstr)"
     Base.depwarn("$(nstr)uf$f is deprecated, please use reinterpret(N$(i)f$f, $cstr) instead", :*)
     reinterpret(Normed{T,f}, convert(T, n))
@@ -54,4 +54,3 @@ const uf16 = NormedConstructor{UInt16,16}()
 
 @deprecate_binding UfixedConstructor NormedConstructor
 @deprecate_binding UFixedConstructor NormedConstructor
-

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -19,7 +19,7 @@ signbits{X<:Fixed}(::Type{X}) = 1
 
 for T in (Int8, Int16, Int32, Int64)
     for f in 0:sizeof(T)*8-1
-        sym = Symbol(takebuf_string(showtype(_iotypealias, Fixed{T,f})))
+        sym = Symbol(String(take!(showtype(_iotypealias, Fixed{T,f}))))
         @eval begin
             typealias $sym Fixed{$T,$f}
             export $sym

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -17,7 +17,7 @@ signbits{X<:Normed}(::Type{X}) = 0
 
 for T in (UInt8, UInt16, UInt32, UInt64)
     for f in 0:sizeof(T)*8
-        sym = Symbol(takebuf_string(showtype(_iotypealias, Normed{T,f})))
+        sym = Symbol(String(take!(showtype(_iotypealias, Normed{T,f}))))
         @eval begin
             typealias $sym Normed{$T,$f}
             export $sym
@@ -37,8 +37,8 @@ rawone(v) = reinterpret(one(v))
 
 # Conversions
 convert{T<:Normed}(::Type{T}, x::T) = x
-convert{T1,T2,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
-function convert{T,T2,f}(::Type{Normed{T,f}}, x::Normed{T2})
+convert{T1<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
+function convert{T<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T,f}}, x::Normed{T2})
     U = Normed{T,f}
     y = round((rawone(U)/rawone(x))*reinterpret(x))
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,5 +1,7 @@
 using Base.Test
 using FixedPointNumbers
+using Compat
+import Compat.String
 
 function test_op{F,T}(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol)
     # Make sure that the result is representable
@@ -110,7 +112,7 @@ end
 x = Fixed{Int32,5}(0.25)
 iob = IOBuffer()
 show(iob, x)
-str = takebuf_string(iob)
+str = String(take!(iob))
 @test str == "0.25Q26f5"
 @test eval(parse(str)) == x
 

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -1,6 +1,7 @@
 using FixedPointNumbers
 using Base.Test
 using Compat
+import Compat.String
 
 @test reinterpret(N0f8, 0xa2).i  === 0xa2
 @test reinterpret(N6f10, 0x1fa2).i === 0x1fa2
@@ -239,7 +240,7 @@ end
 x = reinterpret(N0f8, 0xaa)
 iob = IOBuffer()
 show(iob, x)
-str = takebuf_string(iob)
+str = String(take!(iob))
 @test str == "0.667N0f8"
 @test eval(parse(str)) == x
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using FixedPointNumbers, Base.Test
 
-if VERSION >= v"0.5.0"
-    @test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))
-end
-
 for f in ["normed.jl", "fixed.jl"]
     println("Testing $f")
     include(f)
+end
+
+if VERSION >= v"0.5.0"
+    @test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))
 end


### PR DESCRIPTION
Ambiguity test still fail mostly because of `Union{}`.

`@test_approx_eq` and `@test_approx_eq_eps` depwarn are not fixed either because of missing `Compat` support (and that the deprecation recommendation is a lie even on master).
