### PR TITLE
Work around another ambiguity and centralize floattype, nbitsfrac, an…

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -85,8 +85,16 @@ widen1(x::Integer) = x % widen1(typeof(x))
 typealias ShortInts Union{Int8,UInt8,Int16,UInt16}
 
 floattype{T<:ShortInts,f}(::Type{FixedPoint{T,f}}) = Float32
-floattype{T,f}(::Type{FixedPoint{T,f}}) = Float64
-floattype(x::FixedPoint) = floattype(supertype(typeof(x)))
+floattype{T<:Integer,f}(::Type{FixedPoint{T,f}}) = Float64
+floattype{F<:FixedPoint}(::Type{F}) = floattype(supertype(F))
+floattype(x::FixedPoint) = floattype(typeof(x))
+
+nbitsfrac{T<:Integer,f}(::Type{FixedPoint{T,f}}) = f
+nbitsfrac{F<:FixedPoint}(::Type{F}) = nbitsfrac(supertype(F))
+
+rawtype{T<:Integer,f}(::Type{FixedPoint{T,f}}) = T
+rawtype{F<:FixedPoint}(::Type{F}) = rawtype(supertype(F))
+rawtype(x::FixedPoint) = rawtype(typeof(x))
 
 # This IOBuffer is used during module definition to generate typealias names
 _iotypealias = IOBuffer()

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -10,9 +10,6 @@ end
 
 reinterpret{T<:Signed, f}(::Type{Fixed{T,f}}, x::T) = Fixed{T,f}(x, 0)
 
-  rawtype{T,f}(::Type{Fixed{T,f}}) = T
-nbitsfrac{T,f}(::Type{Fixed{T,f}}) = f
-floattype{T<:Fixed}(::Type{T}) = floattype(supertype(T))
 typechar{X<:Fixed}(::Type{X}) = 'Q'
 signbits{X<:Fixed}(::Type{X}) = 1
 

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -8,10 +8,6 @@ immutable Normed{T<:Unsigned,f} <: FixedPoint{T,f}
     (::Type{Normed{T, f}}){T, f}(x) = convert(Normed{T,f}, x)
 end
 
-  rawtype{T,f}(::Type{Normed{T,f}}) = T
-  rawtype(x::Number) = rawtype(typeof(x))
-nbitsfrac{T,f}(::Type{Normed{T,f}}) = f
-floattype{T<:Normed}(::Type{T}) = floattype(supertype(T))
 typechar{X<:Normed}(::Type{X}) = 'N'
 signbits{X<:Normed}(::Type{X}) = 0
 


### PR DESCRIPTION
…d rawtype.

Only two ambiguities left (`signbits` and `typechar`), due to https://github.com/JuliaLang/julia/issues/20246.