### PR TITLE
Force inlining on convert and rem

### DIFF
--- a/src/normed.jl
+++ b/src/normed.jl
@@ -33,42 +33,42 @@ rawone(v) = reinterpret(one(v))
 
 # Conversions
 convert{T<:Unsigned,f}(::Type{Normed{T,f}}, x::Normed{T,f}) = x
-convert{T1<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
-function convert{T<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T,f}}, x::Normed{T2})
+@inline convert{T1<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
+@inline function convert{T<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T,f}}, x::Normed{T2})
     U = Normed{T,f}
     y = round((rawone(U)/rawone(x))*reinterpret(x))
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)
     reinterpret(U, _unsafe_trunc(T, y))
 end
-convert{U<:Normed}(::Type{U}, x::Real) = _convert(U, rawtype(U), x)
+@inline convert{U<:Normed}(::Type{U}, x::Real) = _convert(U, rawtype(U), x)
 
-convert(::Type{N0f16}, x::N0f8) = reinterpret(N0f16, convert(UInt16, 0x0101*reinterpret(x)))
-function _convert{U<:Normed,T}(::Type{U}, ::Type{T}, x)
+@inline convert(::Type{N0f16}, x::N0f8) = reinterpret(N0f16, convert(UInt16, 0x0101*reinterpret(x)))
+@inline function _convert{U<:Normed,T}(::Type{U}, ::Type{T}, x)
     y = round(widen1(rawone(U))*x)
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)
     U(_unsafe_trunc(T, y), 0)
 end
-function _convert{U<:Normed}(::Type{U}, ::Type{UInt128}, x)
+@inline function _convert{U<:Normed}(::Type{U}, ::Type{UInt128}, x)
     y = round(rawone(U)*x)   # for UInt128, we can't widen
     (0 <= y) & (y <= typemax(UInt128)) & (x <= Float64(typemax(U))) || throw_converterror(U, x)
     U(_unsafe_trunc(UInt128, y), 0)
 end
 
 rem{T<:Normed}(x::T, ::Type{T}) = x
-rem{T<:Normed}(x::Normed, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round((rawone(T)/rawone(x))*reinterpret(x))))
-rem{T<:Normed}(x::Real, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round(rawone(T)*x)))
+@inline rem{T<:Normed}(x::Normed, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round((rawone(T)/rawone(x))*reinterpret(x))))
+@inline rem{T<:Normed}(x::Real, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round(rawone(T)*x)))
 
 # convert(::Type{AbstractFloat}, x::Normed) = convert(floattype(x), x)
 float(x::Normed) = convert(floattype(x), x)
 
 convert(::Type{BigFloat}, x::Normed) = reinterpret(x)*(1/BigFloat(rawone(x)))
-function convert{T<:AbstractFloat}(::Type{T}, x::Normed)
+@inline function convert{T<:AbstractFloat}(::Type{T}, x::Normed)
     y = reinterpret(x)*(one(rawtype(x))/convert(T, rawone(x)))
     convert(T, y)  # needed for types like Float16 which promote arithmetic to Float32
 end
 convert(::Type{Bool}, x::Normed) = x == zero(x) ? false : true
-convert{T<:Integer}(::Type{T}, x::Normed) = convert(T, x*(1/one(T)))
-convert{Ti<:Integer}(::Type{Rational{Ti}}, x::Normed) = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))
+@inline convert{T<:Integer}(::Type{T}, x::Normed) = convert(T, x*(1/one(T)))
+@inline convert{Ti<:Integer}(::Type{Rational{Ti}}, x::Normed) = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))
 convert(::Type{Rational}, x::Normed) = reinterpret(x)//rawone(x)
 
 # Traits

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -44,7 +44,7 @@ end
 
 @inline convert(::Type{N0f16}, x::N0f8) = reinterpret(N0f16, convert(UInt16, 0x0101*reinterpret(x)))
 @inline function _convert{U<:Normed,T}(::Type{U}, ::Type{T}, x)
-    y = round(widen1(rawone(U))*x)
+    y = @fastmath round(widen1(rawone(U))*x)
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)
     U(_unsafe_trunc(T, y), 0)
 end
@@ -63,7 +63,7 @@ float(x::Normed) = convert(floattype(x), x)
 
 convert(::Type{BigFloat}, x::Normed) = reinterpret(x)*(1/BigFloat(rawone(x)))
 @inline function convert{T<:AbstractFloat}(::Type{T}, x::Normed)
-    y = reinterpret(x)*(one(rawtype(x))/convert(T, rawone(x)))
+    y = @fastmath reinterpret(x)*(one(rawtype(x))/convert(T, rawone(x)))
     convert(T, y)  # needed for types like Float16 which promote arithmetic to Float32
 end
 convert(::Type{Bool}, x::Normed) = x == zero(x) ? false : true


### PR DESCRIPTION
This leads to a ~30% performance improvement in certain operations. It has a noticeable effect on visualizations.

This doesn't make conversions "perfect," though:
```julia
julia> using FixedPointNumbers
                                                                                   
julia> foo(x) = convert(N0f8, convert(Float32, x))   # in an ideal world, LLVM figures out this is a no-op
foo (generic function with 1 method)                                               
                                                                                   
julia> x = N0f8(0.8)
0.8N0f8                                                                            
                                                                                   
julia> @code_native foo(x)
        .text                                                                      
Filename: REPL[2]                                                                  
        pushq   %rbp                                                               
        movq    %rsp, %rbp                                                         
Source line: 66                                                                    
        movzbl  (%rdi), %eax                                                       
        vcvtsi2ssl      %eax, %xmm0, %xmm0                                         
        movabsq $139739572855192, %rax  # imm = 0x7F17A799E198                     
        vmulss  (%rax), %xmm0, %xmm0                                               
        movabsq $139739572855196, %rax  # imm = 0x7F17A799E19C                     
Source line: 47                                                                    
        vmovss  (%rax), %xmm2           # xmm2 = mem[0],zero,zero,zero             
        vmulss  %xmm2, %xmm0, %xmm1                                                
        vroundss        $4, %xmm1, %xmm0, %xmm1                                    
Source line: 48                                                                    
        vucomiss        %xmm1, %xmm2                                               
        jb      L71
        vxorps  %xmm2, %xmm2, %xmm2
        vucomiss        %xmm2, %xmm1
        jb      L71
Source line: 1
        vcvttss2si      %xmm1, %eax
        popq    %rbp
        retq
Source line: 48
L71:
        movabsq $throw_converterror, %rax
        movabsq $139739908406960, %rdi  # imm = 0x7F17BB99FEB0
        callq   *%rax
        nopl    (%rax)
```
