### PR TITLE
Fix package on 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("FixedPointNumbers")'
-    - julia -e 'if VERSION >= v"0.6.0-dev.565" Pkg.test("FixedPointNumbers"; coverage=true); else cd(Pkg.dir("FixedPointNumbers", "test")); include("runtests.jl"); end '
+    - julia -e 'Pkg.test("FixedPointNumbers"; coverage=true)'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'if VERSION >= v"0.6.0-dev.565" cd(Pkg.dir("FixedPointNumbers")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder()); end'
+  - julia -e 'cd(Pkg.dir("FixedPointNumbers")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-Compat 0.17.0
+julia 0.6

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -16,11 +16,9 @@ if isdefined(Base, :rem1)
 end
 using Base: @pure
 
-using Compat
-
 # T => BaseType
 # f => Number of Bytes reserved for fractional part
-@compat abstract type FixedPoint{T <: Integer, f} <: Real end
+abstract type FixedPoint{T <: Integer, f} <: Real end
 
 
 export
@@ -39,21 +37,21 @@ export
     scaledual
 
 reinterpret(x::FixedPoint) = x.i
-reinterpret{T,f}(::Type{T}, x::FixedPoint{T,f}) = x.i
+reinterpret(::Type{T}, x::FixedPoint{T,f}) where {T,f} = x.i
 
 # construction using the (approximate) intended value, i.e., N0f8
-*{X<:FixedPoint}(x::Real, ::Type{X}) = X(x)
+*(x::Real, ::Type{X}) where {X<:FixedPoint} = X(x)
 
 # comparison
-=={T <: FixedPoint}(x::T, y::T) = x.i == y.i
- <{T <: FixedPoint}(x::T, y::T) = x.i  < y.i
-<={T <: FixedPoint}(x::T, y::T) = x.i <= y.i
+==(x::T, y::T) where {T <: FixedPoint} = x.i == y.i
+ <(x::T, y::T) where {T <: FixedPoint} = x.i  < y.i
+<=(x::T, y::T) where {T <: FixedPoint} = x.i <= y.i
 """
     isapprox(x::FixedPoint, y::FixedPoint; rtol=0, atol=max(eps(x), eps(y)))
 
 For FixedPoint numbers, the default criterion is that `x` and `y` differ by no more than `eps`, the separation between adjacent fixed-point numbers.
 """
-function isapprox{T<:FixedPoint}(x::T, y::T; rtol=0, atol=max(eps(x), eps(y)))
+function isapprox(x::T, y::T; rtol=0, atol=max(eps(x), eps(y))) where {T <: FixedPoint}
     maxdiff = T(atol+rtol*max(abs(x), abs(y)))
     rx, ry, rd = reinterpret(x), reinterpret(y), reinterpret(maxdiff)
     abs(signed(widen1(rx))-signed(widen1(ry))) <= rd
@@ -63,13 +61,13 @@ function isapprox(x::FixedPoint, y::FixedPoint; rtol=0, atol=max(eps(x), eps(y))
 end
 
 # predicates
-isinteger{T,f}(x::FixedPoint{T,f}) = (x.i&(1<<f-1)) == 0
+isinteger(x::FixedPoint{T,f}) where {T,f} = (x.i&(1<<f-1)) == 0
 
 # traits
-typemax{T<: FixedPoint}(::Type{T}) = T(typemax(rawtype(T)), 0)
-typemin{T<: FixedPoint}(::Type{T}) = T(typemin(rawtype(T)), 0)
-realmin{T<: FixedPoint}(::Type{T}) = eps(T)
-realmax{T<: FixedPoint}(::Type{T}) = typemax(T)
+typemax(::Type{T}) where {T <: FixedPoint} = T(typemax(rawtype(T)), 0)
+typemin(::Type{T}) where {T <: FixedPoint} = T(typemin(rawtype(T)), 0)
+realmin(::Type{T}) where {T <: FixedPoint} = eps(T)
+realmax(::Type{T}) where {T <: FixedPoint} = typemax(T)
 
 widen1(::Type{Int8})   = Int16
 widen1(::Type{UInt8})  = UInt16
@@ -84,16 +82,16 @@ widen1(x::Integer) = x % widen1(typeof(x))
 
 const ShortInts = Union{Int8,UInt8,Int16,UInt16}
 
-floattype{T<:ShortInts,f}(::Type{FixedPoint{T,f}}) = Float32
-floattype{T<:Integer,f}(::Type{FixedPoint{T,f}}) = Float64
-floattype{F<:FixedPoint}(::Type{F}) = floattype(supertype(F))
+floattype(::Type{FixedPoint{T,f}}) where {T <: ShortInts,f} = Float32
+floattype(::Type{FixedPoint{T,f}}) where {T <: Integer,f} = Float64
+floattype(::Type{F}) where {F <: FixedPoint} = floattype(supertype(F))
 floattype(x::FixedPoint) = floattype(typeof(x))
 
-nbitsfrac{T<:Integer,f}(::Type{FixedPoint{T,f}}) = f
-nbitsfrac{F<:FixedPoint}(::Type{F}) = nbitsfrac(supertype(F))
+nbitsfrac(::Type{FixedPoint{T,f}}) where {T <: Integer,f} = f
+nbitsfrac(::Type{F}) where {F <: FixedPoint} = nbitsfrac(supertype(F))
 
-rawtype{T<:Integer,f}(::Type{FixedPoint{T,f}}) = T
-rawtype{F<:FixedPoint}(::Type{F}) = rawtype(supertype(F))
+rawtype(::Type{FixedPoint{T,f}}) where {T <: Integer,f} = T
+rawtype(::Type{F}) where {F <: FixedPoint} = rawtype(supertype(F))
 rawtype(x::FixedPoint) = rawtype(typeof(x))
 
 # This IOBuffer is used during module definition to generate typealias names
@@ -101,46 +99,46 @@ _iotypealias = IOBuffer()
 
 # Printing. These are used to generate type-symbols, so we need them
 # before we include any files.
-function showtype{X<:FixedPoint}(io::IO, ::Type{X})
+function showtype(io::IO, ::Type{X}) where {X <: FixedPoint}
     print(io, typechar(X))
     f = nbitsfrac(X)
     m = sizeof(X)*8-f-signbits(X)
     print(io, m, 'f', f)
     io
 end
-function show{T,f}(io::IO, x::FixedPoint{T,f})
+function show(io::IO, x::FixedPoint{T,f}) where {T,f}
     showcompact(io, x)
     showtype(io, typeof(x))
 end
 const _log2_10 = 3.321928094887362
-showcompact{T,f}(io::IO, x::FixedPoint{T,f}) = show(io, round(convert(Float64,x), ceil(Int,f/_log2_10)))
+showcompact(io::IO, x::FixedPoint{T,f}) where {T,f} = show(io, round(convert(Float64,x), ceil(Int,f/_log2_10)))
 
 
 include("fixed.jl")
 include("normed.jl")
 include("deprecations.jl")
 
-eps{T<:FixedPoint}(::Type{T}) = T(one(rawtype(T)),0)
-eps{T<:FixedPoint}(::T) = eps(T)
-sizeof{T<:FixedPoint}(::Type{T}) = sizeof(rawtype(T))
+eps(::Type{T}) where {T <: FixedPoint} = T(one(rawtype(T)),0)
+eps(::T) where {T <: FixedPoint} = eps(T)
+sizeof(::Type{T}) where {T <: FixedPoint} = sizeof(rawtype(T))
 
 # Promotions for reductions
 const Treduce = Float64
-r_promote{T}(::typeof(+), x::FixedPoint{T}) = Treduce(x)
-r_promote{T}(::typeof(*), x::FixedPoint{T}) = Treduce(x)
+r_promote(::typeof(+), x::FixedPoint{T}) where {T} = Treduce(x)
+r_promote(::typeof(*), x::FixedPoint{T}) where {T} = Treduce(x)
 
-reducedim_init{T<:FixedPoint}(f::typeof(identity),
+reducedim_init(f::typeof(identity),
                               op::typeof(+),
-                              A::AbstractArray{T}, region) =
+                              A::AbstractArray{T}, region) where {T <: FixedPoint} =
     reducedim_initarray(A, region, zero(Treduce))
-reducedim_init{T<:FixedPoint}(f::typeof(identity),
+reducedim_init(f::typeof(identity),
                               op::typeof(*),
-                              A::AbstractArray{T}, region) =
+                              A::AbstractArray{T}, region) where {T <: FixedPoint} =
     reducedim_initarray(A, region, one(Treduce))
 
 for f in (:div, :fld, :fld1)
     @eval begin
-        $f{T<:FixedPoint}(x::T, y::T) = $f(reinterpret(x),reinterpret(y))
+        $f(x::T, y::T) where {T <: FixedPoint} = $f(reinterpret(x),reinterpret(y))
     end
 end
 for f in (:rem, :mod, :mod1, :rem1, :min, :max)
@@ -148,20 +146,20 @@ for f in (:rem, :mod, :mod1, :rem1, :min, :max)
         continue
     end
     @eval begin
-        $f{T<:FixedPoint}(x::T, y::T) = T($f(reinterpret(x),reinterpret(y)),0)
+        $f(x::T, y::T) where {T <: FixedPoint} = T($f(reinterpret(x),reinterpret(y)),0)
     end
 end
 
 # When multiplying by a float, reduce two multiplies to one.
 # Particularly useful for arrays.
 scaledual(Tdual::Type, x) = one(Tdual), x
-scaledual{Tdual<:Number}(b::Tdual, x) = b, x
-scaledual{T<:FixedPoint}(Tdual::Type, x::Union{T,AbstractArray{T}}) =
+scaledual(b::Tdual, x) where {Tdual <: Number} = b, x
+scaledual(Tdual::Type, x::Union{T,AbstractArray{T}}) where {T <: FixedPoint} =
     convert(Tdual, 1/one(T)), reinterpret(rawtype(T), x)
-scaledual{Tdual<:Number, T<:FixedPoint}(b::Tdual, x::Union{T,AbstractArray{T}}) =
+scaledual(b::Tdual, x::Union{T,AbstractArray{T}}) where {Tdual <: Number,T <: FixedPoint} =
     convert(Tdual, b/one(T)), reinterpret(rawtype(T), x)
 
-@noinline function throw_converterror{T<:FixedPoint}(::Type{T}, x)
+@noinline function throw_converterror(::Type{T}, x) where {T <: FixedPoint}
     n = 2^(8*sizeof(T))
     bitstring = sizeof(T) == 1 ? "an 8-bit" : "a $(8*sizeof(T))-bit"
     io = IOBuffer()
@@ -170,7 +168,7 @@ scaledual{Tdual<:Number, T<:FixedPoint}(b::Tdual, x::Union{T,AbstractArray{T}}) 
     throw(ArgumentError("$T is $bitstring type representing $n values from $Tmin to $Tmax; cannot represent $x"))
 end
 
-rand{T<:FixedPoint}(::Type{T}) = reinterpret(T, rand(rawtype(T)))
-rand{T<:FixedPoint}(::Type{T}, sz::Dims) = reinterpret(T, rand(rawtype(T), sz))
+rand(::Type{T}) where {T <: FixedPoint} = reinterpret(T, rand(rawtype(T)))
+rand(::Type{T}, sz::Dims) where {T <: FixedPoint} = reinterpret(T, rand(rawtype(T), sz))
 
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -31,7 +31,7 @@ const UF = (N0f8, N6f10, N4f12, N2f14, N0f16)
 ## The next lines mimic the floating-point literal syntax "3.2f0"
 # construction using a UInt, i.e., 0xccuf8
 struct NormedConstructor{T,f} end
-function *{T,f}(n::Integer, ::NormedConstructor{T,f})
+function *(n::Integer, ::NormedConstructor{T,f}) where {T,f}
     i = 8*sizeof(T)-f
     io = IOBuffer()
     show(io, n)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -28,12 +28,6 @@ const UF = (N0f8, N6f10, N4f12, N2f14, N0f16)
 @deprecate ufixed14(x) N2f14(x)
 @deprecate ufixed16(x) N0f16(x)
 
-Compat.@dep_vectorize_1arg Real ufixed8
-Compat.@dep_vectorize_1arg Real ufixed10
-Compat.@dep_vectorize_1arg Real ufixed12
-Compat.@dep_vectorize_1arg Real ufixed14
-Compat.@dep_vectorize_1arg Real ufixed16
-
 ## The next lines mimic the floating-point literal syntax "3.2f0"
 # construction using a UInt, i.e., 0xccuf8
 struct NormedConstructor{T,f} end

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -4,14 +4,14 @@ struct Fixed{T <: Signed,f} <: FixedPoint{T,  f}
 
     # constructor for manipulating the representation;
     # selected by passing an extra dummy argument
-    (::Type{Fixed{T, f}}){T, f}(i::Integer, _) = new{T, f}(i % T)
-    (::Type{Fixed{T, f}}){T, f}(x) = convert(Fixed{T,f}, x)
+    (::Type{Fixed{T, f}})(i::Integer, _) where {T,f} = new{T, f}(i % T)
+    (::Type{Fixed{T, f}})(x) where {T,f} = convert(Fixed{T,f}, x)
 end
 
-reinterpret{T<:Signed, f}(::Type{Fixed{T,f}}, x::T) = Fixed{T,f}(x, 0)
+reinterpret(::Type{Fixed{T,f}}, x::T) where {T <: Signed,f} = Fixed{T,f}(x, 0)
 
-typechar{X<:Fixed}(::Type{X}) = 'Q'
-signbits{X<:Fixed}(::Type{X}) = 1
+typechar(::Type{X}) where {X <: Fixed} = 'Q'
+signbits(::Type{X}) where {X <: Fixed} = 1
 
 for T in (Int8, Int16, Int32, Int64)
     for f in 0:sizeof(T)*8-1
@@ -24,52 +24,52 @@ for T in (Int8, Int16, Int32, Int64)
 end
 
 # basic operators
--{T,f}(x::Fixed{T,f}) = Fixed{T,f}(-x.i,0)
-abs{T,f}(x::Fixed{T,f}) = Fixed{T,f}(abs(x.i),0)
+-(x::Fixed{T,f}) where {T,f} = Fixed{T,f}(-x.i,0)
+abs(x::Fixed{T,f}) where {T,f} = Fixed{T,f}(abs(x.i),0)
 
-+{T,f}(x::Fixed{T,f}, y::Fixed{T,f}) = Fixed{T,f}(x.i+y.i,0)
--{T,f}(x::Fixed{T,f}, y::Fixed{T,f}) = Fixed{T,f}(x.i-y.i,0)
++(x::Fixed{T,f}, y::Fixed{T,f}) where {T,f} = Fixed{T,f}(x.i+y.i,0)
+-(x::Fixed{T,f}, y::Fixed{T,f}) where {T,f} = Fixed{T,f}(x.i-y.i,0)
 
 # with truncation:
 #*{f}(x::Fixed32{f}, y::Fixed32{f}) = Fixed32{f}(Base.widemul(x.i,y.i)>>f,0)
 # with rounding up:
-*{T,f}(x::Fixed{T,f}, y::Fixed{T,f}) = Fixed{T,f}((Base.widemul(x.i,y.i) + (convert(widen(T), 1) << (f-1) ))>>f,0)
+*(x::Fixed{T,f}, y::Fixed{T,f}) where {T,f} = Fixed{T,f}((Base.widemul(x.i,y.i) + (convert(widen(T), 1) << (f-1) ))>>f,0)
 
-/{T,f}(x::Fixed{T,f}, y::Fixed{T,f}) = Fixed{T,f}(div(convert(widen(T), x.i) << f, y.i), 0)
+/(x::Fixed{T,f}, y::Fixed{T,f}) where {T,f} = Fixed{T,f}(div(convert(widen(T), x.i) << f, y.i), 0)
 
 
 # # conversions and promotions
-convert{T,f}(::Type{Fixed{T,f}}, x::Integer) = Fixed{T,f}(round(T, convert(widen1(T),x)<<f),0)
-convert{T,f}(::Type{Fixed{T,f}}, x::AbstractFloat) = Fixed{T,f}(round(T, trunc(widen1(T),x)<<f + rem(x,1)*(1<<f)),0)
-convert{T,f}(::Type{Fixed{T,f}}, x::Rational) = Fixed{T,f}(x.num)/Fixed{T,f}(x.den)
+convert(::Type{Fixed{T,f}}, x::Integer) where {T,f} = Fixed{T,f}(round(T, convert(widen1(T),x)<<f),0)
+convert(::Type{Fixed{T,f}}, x::AbstractFloat) where {T,f} = Fixed{T,f}(round(T, trunc(widen1(T),x)<<f + rem(x,1)*(1<<f)),0)
+convert(::Type{Fixed{T,f}}, x::Rational) where {T,f} = Fixed{T,f}(x.num)/Fixed{T,f}(x.den)
 
-rem{T,f}(x::Integer, ::Type{Fixed{T,f}}) = Fixed{T,f}(rem(x,T)<<f,0)
-rem{T,f}(x::Real,    ::Type{Fixed{T,f}}) = Fixed{T,f}(rem(Integer(trunc(x)),T)<<f + rem(Integer(round(rem(x,1)*(1<<f))),T),0)
+rem(x::Integer, ::Type{Fixed{T,f}}) where {T,f} = Fixed{T,f}(rem(x,T)<<f,0)
+rem(x::Real,    ::Type{Fixed{T,f}}) where {T,f} = Fixed{T,f}(rem(Integer(trunc(x)),T)<<f + rem(Integer(round(rem(x,1)*(1<<f))),T),0)
 
 # convert{T,f}(::Type{AbstractFloat}, x::Fixed{T,f}) = convert(floattype(x), x)
 float(x::Fixed) = convert(floattype(x), x)
 
-convert{T,f}(::Type{BigFloat}, x::Fixed{T,f}) =
+convert(::Type{BigFloat}, x::Fixed{T,f}) where {T,f} =
     convert(BigFloat,x.i>>f) + convert(BigFloat,x.i&(1<<f - 1))/convert(BigFloat,1<<f)
-convert{TF<:AbstractFloat,T,f}(::Type{TF}, x::Fixed{T,f}) =
+convert(::Type{TF}, x::Fixed{T,f}) where {TF <: AbstractFloat,T,f} =
     convert(TF,x.i>>f) + convert(TF,x.i&(1<<f - 1))/convert(TF,1<<f)
 
-convert{T,f}(::Type{Bool}, x::Fixed{T,f}) = x.i!=0
-function convert{T,f}(::Type{Integer}, x::Fixed{T,f})
+convert(::Type{Bool}, x::Fixed{T,f}) where {T,f} = x.i!=0
+function convert(::Type{Integer}, x::Fixed{T,f}) where {T,f}
     isinteger(x) || throw(InexactError())
     convert(Integer, x.i>>f)
 end
-function convert{TI<:Integer, T,f}(::Type{TI}, x::Fixed{T,f})
+function convert(::Type{TI}, x::Fixed{T,f}) where {TI <: Integer,T,f}
     isinteger(x) || throw(InexactError())
     convert(TI, x.i>>f)
 end
 
-convert{TR<:Rational,T,f}(::Type{TR}, x::Fixed{T,f}) =
+convert(::Type{TR}, x::Fixed{T,f}) where {TR <: Rational,T,f} =
     convert(TR, x.i>>f + (x.i&(1<<f-1))//(1<<f))
 
-promote_rule{T,f,TI<:Integer}(ft::Type{Fixed{T,f}}, ::Type{TI}) = Fixed{T,f}
-promote_rule{T,f,TF<:AbstractFloat}(::Type{Fixed{T,f}}, ::Type{TF}) = TF
-promote_rule{T,f,TR}(::Type{Fixed{T,f}}, ::Type{Rational{TR}}) = Rational{TR}
+promote_rule(ft::Type{Fixed{T,f}}, ::Type{TI}) where {T,f,TI <: Integer} = Fixed{T,f}
+promote_rule(::Type{Fixed{T,f}}, ::Type{TF}) where {T,f,TF <: AbstractFloat} = TF
+promote_rule(::Type{Fixed{T,f}}, ::Type{Rational{TR}}) where {T,f,TR} = Rational{TR}
 
 # TODO: Document and check that it still does the right thing.
-decompose{T,f}(x::Fixed{T,f}) = x.i, -f, 1
+decompose(x::Fixed{T,f}) where {T,f} = x.i, -f, 1

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -4,12 +4,12 @@
 struct Normed{T<:Unsigned,f} <: FixedPoint{T,f}
     i::T
 
-    (::Type{Normed{T, f}}){T, f}(i::Integer,_) = new{T, f}(i%T)   # for setting by raw representation
-    (::Type{Normed{T, f}}){T, f}(x) = convert(Normed{T,f}, x)
+    (::Type{Normed{T, f}})(i::Integer,_) where {T,f} = new{T, f}(i%T)   # for setting by raw representation
+    (::Type{Normed{T, f}})(x) where {T,f} = convert(Normed{T,f}, x)
 end
 
-typechar{X<:Normed}(::Type{X}) = 'N'
-signbits{X<:Normed}(::Type{X}) = 0
+typechar(::Type{X}) where {X <: Normed} = 'N'
+signbits(::Type{X}) where {X <: Normed} = 0
 
 for T in (UInt8, UInt16, UInt32, UInt64)
     for f in 0:sizeof(T)*8
@@ -21,10 +21,10 @@ for T in (UInt8, UInt16, UInt32, UInt64)
     end
 end
 
-reinterpret{T<:Unsigned, f}(::Type{Normed{T,f}}, x::T) = Normed{T,f}(x, 0)
+reinterpret(::Type{Normed{T,f}}, x::T) where {T <: Unsigned,f} = Normed{T,f}(x, 0)
 
-zero{T,f}(::Type{Normed{T,f}}) = Normed{T,f}(zero(T),0)
-function one{T<:Normed}(::Type{T})
+zero(::Type{Normed{T,f}}) where {T,f} = Normed{T,f}(zero(T),0)
+function one(::Type{T}) where {T <: Normed}
     T(typemax(rawtype(T)) >> (8*sizeof(T)-nbitsfrac(T)), 0)
 end
 zero(x::Normed) = zero(typeof(x))
@@ -32,71 +32,71 @@ zero(x::Normed) = zero(typeof(x))
 rawone(v) = reinterpret(one(v))
 
 # Conversions
-convert{U<:Normed}(::Type{U}, x::U) = x
-convert{T1<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T1,f}}, x::Normed{T2,f}) = Normed{T1,f}(convert(T1, x.i), 0)
-function convert{T<:Unsigned,T2<:Unsigned,f}(::Type{Normed{T,f}}, x::Normed{T2})
+convert(::Type{U}, x::U) where {U <: Normed} = x
+convert(::Type{Normed{T1,f}}, x::Normed{T2,f}) where {T1 <: Unsigned,T2 <: Unsigned,f} = Normed{T1,f}(convert(T1, x.i), 0)
+function convert(::Type{Normed{T,f}}, x::Normed{T2}) where {T <: Unsigned,T2 <: Unsigned,f}
     U = Normed{T,f}
     y = round((rawone(U)/rawone(x))*reinterpret(x))
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)
     reinterpret(U, _unsafe_trunc(T, y))
 end
-convert{U<:Normed}(::Type{U}, x::Real) = _convert(U, rawtype(U), x)
+convert(::Type{U}, x::Real) where {U <: Normed} = _convert(U, rawtype(U), x)
 
 convert(::Type{N0f16}, x::N0f8) = reinterpret(N0f16, convert(UInt16, 0x0101*reinterpret(x)))
-function _convert{U<:Normed,T}(::Type{U}, ::Type{T}, x)
+function _convert(::Type{U}, ::Type{T}, x) where {U <: Normed,T}
     y = round(widen1(rawone(U))*x)
     (0 <= y) & (y <= typemax(T)) || throw_converterror(U, x)
     U(_unsafe_trunc(T, y), 0)
 end
-function _convert{U<:Normed}(::Type{U}, ::Type{UInt128}, x)
+function _convert(::Type{U}, ::Type{UInt128}, x) where {U <: Normed}
     y = round(rawone(U)*x)   # for UInt128, we can't widen
     (0 <= y) & (y <= typemax(UInt128)) & (x <= Float64(typemax(U))) || throw_converterror(U, x)
     U(_unsafe_trunc(UInt128, y), 0)
 end
 
-rem{T<:Normed}(x::T, ::Type{T}) = x
-rem{T<:Normed}(x::Normed, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round((rawone(T)/rawone(x))*reinterpret(x))))
-rem{T<:Normed}(x::Real, ::Type{T}) = reinterpret(T, _unsafe_trunc(rawtype(T), round(rawone(T)*x)))
+rem(x::T, ::Type{T}) where {T <: Normed} = x
+rem(x::Normed, ::Type{T}) where {T <: Normed} = reinterpret(T, _unsafe_trunc(rawtype(T), round((rawone(T)/rawone(x))*reinterpret(x))))
+rem(x::Real, ::Type{T}) where {T <: Normed} = reinterpret(T, _unsafe_trunc(rawtype(T), round(rawone(T)*x)))
 
 # convert(::Type{AbstractFloat}, x::Normed) = convert(floattype(x), x)
 float(x::Normed) = convert(floattype(x), x)
 
 convert(::Type{BigFloat}, x::Normed) = reinterpret(x)*(1/BigFloat(rawone(x)))
-function convert{T<:AbstractFloat}(::Type{T}, x::Normed)
+function convert(::Type{T}, x::Normed) where {T <: AbstractFloat}
     y = reinterpret(x)*(one(rawtype(x))/convert(T, rawone(x)))
     convert(T, y)  # needed for types like Float16 which promote arithmetic to Float32
 end
 convert(::Type{Bool}, x::Normed) = x == zero(x) ? false : true
 convert(::Type{Integer}, x::Normed) = convert(Integer, x*1.0)
-convert{T<:Integer}(::Type{T}, x::Normed) = convert(T, x*(1/one(T)))
-convert{Ti<:Integer}(::Type{Rational{Ti}}, x::Normed) = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))
+convert(::Type{T}, x::Normed) where {T <: Integer} = convert(T, x*(1/one(T)))
+convert(::Type{Rational{Ti}}, x::Normed) where {Ti <: Integer} = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))
 convert(::Type{Rational}, x::Normed) = reinterpret(x)//rawone(x)
 
 # Traits
 abs(x::Normed) = x
 
-(-){T<:Normed}(x::T) = T(-reinterpret(x), 0)
-(~){T<:Normed}(x::T) = T(~reinterpret(x), 0)
+(-)(x::T) where {T <: Normed} = T(-reinterpret(x), 0)
+(~)(x::T) where {T <: Normed} = T(~reinterpret(x), 0)
 
-+{T,f}(x::Normed{T,f}, y::Normed{T,f}) = Normed{T,f}(convert(T, x.i+y.i),0)
--{T,f}(x::Normed{T,f}, y::Normed{T,f}) = Normed{T,f}(convert(T, x.i-y.i),0)
-*{T<:Normed}(x::T, y::T) = convert(T,convert(floattype(T), x)*convert(floattype(T), y))
-/{T<:Normed}(x::T, y::T) = convert(T,convert(floattype(T), x)/convert(floattype(T), y))
++(x::Normed{T,f}, y::Normed{T,f}) where {T,f} = Normed{T,f}(convert(T, x.i+y.i),0)
+-(x::Normed{T,f}, y::Normed{T,f}) where {T,f} = Normed{T,f}(convert(T, x.i-y.i),0)
+*(x::T, y::T) where {T <: Normed} = convert(T,convert(floattype(T), x)*convert(floattype(T), y))
+/(x::T, y::T) where {T <: Normed} = convert(T,convert(floattype(T), x)/convert(floattype(T), y))
 
 # Comparisons
- <{T<:Normed}(x::T, y::T) = reinterpret(x) < reinterpret(y)
-<={T<:Normed}(x::T, y::T) = reinterpret(x) <= reinterpret(y)
+ <(x::T, y::T) where {T <: Normed} = reinterpret(x) < reinterpret(y)
+<=(x::T, y::T) where {T <: Normed} = reinterpret(x) <= reinterpret(y)
 
 # Functions
-trunc{T<:Normed}(x::T) = T(div(reinterpret(x), rawone(T))*rawone(T),0)
-floor{T<:Normed}(x::T) = trunc(x)
-function round{T,f}(x::Normed{T,f})
+trunc(x::T) where {T <: Normed} = T(div(reinterpret(x), rawone(T))*rawone(T),0)
+floor(x::T) where {T <: Normed} = trunc(x)
+function round(x::Normed{T,f}) where {T,f}
     mask = convert(T, 1<<(f-1))
     y = trunc(x)
     return convert(T, reinterpret(x)-reinterpret(y)) & mask>0 ?
             Normed{T,f}(y+one(Normed{T,f})) : y
 end
-function ceil{T,f}(x::Normed{T,f})
+function ceil(x::Normed{T,f}) where {T,f}
     k = 8*sizeof(T)-f
     mask = (typemax(T)<<k)>>k
     y = trunc(x)
@@ -104,19 +104,19 @@ function ceil{T,f}(x::Normed{T,f})
             Normed{T,f}(y+one(Normed{T,f})) : y
 end
 
-trunc{T<:Integer}(::Type{T}, x::Normed) = convert(T, div(reinterpret(x), rawone(x)))
-round{T<:Integer}(::Type{T}, x::Normed) = round(T, reinterpret(x)/rawone(x))
-floor{T<:Integer}(::Type{T}, x::Normed) = trunc(T, x)
- ceil{T<:Integer}(::Type{T}, x::Normed) =  ceil(T, reinterpret(x)/rawone(x))
+trunc(::Type{T}, x::Normed) where {T <: Integer} = convert(T, div(reinterpret(x), rawone(x)))
+round(::Type{T}, x::Normed) where {T <: Integer} = round(T, reinterpret(x)/rawone(x))
+floor(::Type{T}, x::Normed) where {T <: Integer} = trunc(T, x)
+ ceil(::Type{T}, x::Normed) where {T <: Integer} =  ceil(T, reinterpret(x)/rawone(x))
 
 isfinite(x::Normed) = true
 isnan(x::Normed) = false
 isinf(x::Normed) = false
 
-bswap{f}(x::Normed{UInt8,f}) = x
+bswap(x::Normed{UInt8,f}) where {f} = x
 bswap(x::Normed)  = typeof(x)(bswap(reinterpret(x)),0)
 
-function minmax{T<:Normed}(x::T, y::T)
+function minmax(x::T, y::T) where {T <: Normed}
     a, b = minmax(reinterpret(x), reinterpret(y))
     T(a,0), T(b,0)
 end
@@ -124,9 +124,9 @@ end
 # Iteration
 # The main subtlety here is that iterating over 0x00uf8:0xffuf8 will wrap around
 # unless we iterate using a wider type
-@inline start{T<:Normed}(r::StepRange{T}) = widen1(reinterpret(r.start))
-@inline next{T<:Normed}(r::StepRange{T}, i::Integer) = (T(i,0), i+reinterpret(r.step))
-@inline function done{T<:Normed}(r::StepRange{T}, i::Integer)
+@inline start(r::StepRange{T}) where {T <: Normed} = widen1(reinterpret(r.start))
+@inline next(r::StepRange{T}, i::Integer) where {T <: Normed} = (T(i,0), i+reinterpret(r.step))
+@inline function done(r::StepRange{T}, i::Integer) where {T <: Normed}
     i1, i2 = reinterpret(r.start), reinterpret(r.stop)
     isempty(r) | (i < min(i1, i2)) | (i > max(i1, i2))
 end
@@ -137,12 +137,12 @@ function decompose(x::Normed)
 end
 
 # Promotions
-promote_rule{T<:Normed,Tf<:AbstractFloat}(::Type{T}, ::Type{Tf}) = promote_type(floattype(T), Tf)
-promote_rule{T<:Normed, R<:Rational}(::Type{T}, ::Type{R}) = R
-function promote_rule{T<:Normed, Ti<:Union{Signed,Unsigned}}(::Type{T}, ::Type{Ti})
+promote_rule(::Type{T}, ::Type{Tf}) where {T <: Normed,Tf <: AbstractFloat} = promote_type(floattype(T), Tf)
+promote_rule(::Type{T}, ::Type{R}) where {T <: Normed,R <: Rational} = R
+function promote_rule(::Type{T}, ::Type{Ti}) where {T <: Normed,Ti <: Union{Signed, Unsigned}}
     floattype(T)
 end
-@generated function promote_rule{T1,T2,f1,f2}(::Type{Normed{T1,f1}}, ::Type{Normed{T2,f2}})
+@generated function promote_rule(::Type{Normed{T1,f1}}, ::Type{Normed{T2,f2}}) where {T1,T2,f1,f2}
     f = max(f1, f2)  # ensure we have enough precision
     T = promote_type(T1, T2)
     # make sure we have enough integer bits
@@ -155,5 +155,5 @@ end
     :(Normed{$T,$f})
 end
 
-_unsafe_trunc{T}(::Type{T}, x::Integer) = x % T
-_unsafe_trunc{T}(::Type{T}, x)          = unsafe_trunc(T, x)
+_unsafe_trunc(::Type{T}, x::Integer) where {T} = x % T
+_unsafe_trunc(::Type{T}, x) where {T}          = unsafe_trunc(T, x)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,16 +1,14 @@
 using Base.Test
 using FixedPointNumbers
-using Compat
-import Compat.String
 
-function test_op{F,T}(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol)
+function test_op(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol) where {F,T}
     # Make sure that the result is representable
     (typemin(T) <= fun(fxf, fyf) <= typemax(T)) || return nothing
     @assert abs(fun(fx, fy) - convert(T, fun(fxf, fyf))) <= tol
     @assert abs(convert(Float64, fun(fx, fy)) - fun(fxf, fyf)) <= tol
 end
 
-function test_fixed{T}(::Type{T}, f)
+function test_fixed(::Type{T}, f) where {T}
     values = [-10:0.01:10; -180:.01:-160; 160:.01:180]
     tol = 2.0^-f
     for x in values

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -1,7 +1,5 @@
 using FixedPointNumbers
 using Base.Test
-using Compat
-import Compat.String
 
 @test reinterpret(N0f8, 0xa2).i  === 0xa2
 @test reinterpret(N6f10, 0x1fa2).i === 0x1fa2
@@ -24,7 +22,7 @@ import Compat.String
 @test N0f8(1.0) == reinterpret(N0f8, 0xff)
 @test N0f8(0.5) == reinterpret(N0f8, 0x80)
 @test N2f14(1.0) == reinterpret(N2f14, 0x3fff)
-v = @compat N4f12.([2])
+v = N4f12.([2])
 @test v == N4f12[reinterpret(N4f12, 0x1ffe)]
 @test isa(v, Vector{N4f12})
 
@@ -145,7 +143,7 @@ for T in (FixedPointNumbers.UF..., UF2...)
     @test (x^2.1) ≈ convert(Float64, x)^2.1
 end
 
-function testtrunc{T}(inc::T)
+function testtrunc(inc::T) where {T}
     incf = convert(Float64, inc)
     tm = reinterpret(typemax(T))/reinterpret(one(T))
     x = zero(T)
@@ -181,7 +179,7 @@ for T in (FixedPointNumbers.UF..., UF2...)
     testtrunc(eps(T))
 end
 
-function testapprox{T}(::Type{T})
+function testapprox(::Type{T}) where {T}
     for x = typemin(T):eps(T):typemax(T)-eps(T)
         y = x+eps(T)
         @test x ≈ y


### PR DESCRIPTION
As noted in https://github.com/JuliaMath/FixedPointNumbers.jl/pull/88#issuecomment-320439100, some old deprecated definitions were triggering an error. Rather than figure out how to fix Compat, I took the lazy way out and deleted the definitions (they are ~9months old now). I thought about deleting the rest, but there didn't seem to be a pressing need.