### PR TITLE
Fix test depwarns

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -79,6 +79,7 @@ end
 @test (-67.2 % T).i == round(Int, -67.2*512) % Int16
 
 for T in [Fixed{Int8,7}, Fixed{Int16,8}, Fixed{Int16,10}]
+    local T
     testapprox(T)  # defined in ufixed.jl
 end
 
@@ -97,6 +98,7 @@ acmp = Float64(a[1])*Float64(a[2])
 
 x = Fixed{Int8,8}(0.3)
 for T in (Float16, Float32, Float64, BigFloat)
+    local T
     y = convert(T, x)
     @test isa(y, T)
 end
@@ -118,6 +120,7 @@ str = String(take!(iob))
 @test eval(parse(str)) == x
 
 for T in (Fixed{Int8,8}, Fixed{Int16,8}, Fixed{Int16,10}, Fixed{Int32,16})
+    local T
     a = rand(T)
     @test isa(a, T)
     a = rand(T, (3, 5))

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -211,6 +211,7 @@ r = reinterpret(N0f8, 0x01):reinterpret(N0f8, 0x01):reinterpret(N0f8, convert(UI
 
 counter = 0
 for x in N0f8(0):eps(N0f8):N0f8(1)
+    local x
     counter += 1
 end
 @test counter == 256


### PR DESCRIPTION
Both the new and the old semantics works in this case, so it's mostly just to clean up the test output...