### PR TITLE
one->oneunit where appropriate

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -7,7 +7,7 @@ using Base: reducedim_initarray
 import Base: ==, <, <=, -, +, *, /, ~, isapprox,
              convert, promote_rule, show, showcompact, isinteger, abs, decompose,
              isnan, isinf, isfinite,
-             zero, one, typemin, typemax, realmin, realmax, eps, sizeof, reinterpret,
+             zero, oneunit, one, typemin, typemax, realmin, realmax, eps, sizeof, reinterpret,
              float, trunc, round, floor, ceil, bswap,
              div, fld, rem, mod, mod1, fld1, min, max, minmax,
              start, next, done, r_promote, reducedim_init, rand
@@ -118,7 +118,7 @@ include("fixed.jl")
 include("normed.jl")
 include("deprecations.jl")
 
-eps(::Type{T}) where {T <: FixedPoint} = T(one(rawtype(T)),0)
+eps(::Type{T}) where {T <: FixedPoint} = T(oneunit(rawtype(T)),0)
 eps(::T) where {T <: FixedPoint} = eps(T)
 sizeof(::Type{T}) where {T <: FixedPoint} = sizeof(rawtype(T))
 
@@ -134,7 +134,7 @@ reducedim_init(f::typeof(identity),
 reducedim_init(f::typeof(identity),
                               op::typeof(*),
                               A::AbstractArray{T}, region) where {T <: FixedPoint} =
-    reducedim_initarray(A, region, one(Treduce))
+    reducedim_initarray(A, region, oneunit(Treduce))
 
 for f in (:div, :fld, :fld1)
     @eval begin
@@ -152,12 +152,12 @@ end
 
 # When multiplying by a float, reduce two multiplies to one.
 # Particularly useful for arrays.
-scaledual(Tdual::Type, x) = one(Tdual), x
+scaledual(Tdual::Type, x) = oneunit(Tdual), x
 scaledual(b::Tdual, x) where {Tdual <: Number} = b, x
 scaledual(Tdual::Type, x::Union{T,AbstractArray{T}}) where {T <: FixedPoint} =
-    convert(Tdual, 1/one(T)), reinterpret(rawtype(T), x)
+    convert(Tdual, 1/oneunit(T)), reinterpret(rawtype(T), x)
 scaledual(b::Tdual, x::Union{T,AbstractArray{T}}) where {Tdual <: Number,T <: FixedPoint} =
-    convert(Tdual, b/one(T)), reinterpret(rawtype(T), x)
+    convert(Tdual, b/oneunit(T)), reinterpret(rawtype(T), x)
 
 @noinline function throw_converterror(::Type{T}, x) where {T <: FixedPoint}
     n = 2^(8*sizeof(T))

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -24,11 +24,13 @@ end
 reinterpret(::Type{Normed{T,f}}, x::T) where {T <: Unsigned,f} = Normed{T,f}(x, 0)
 
 zero(::Type{Normed{T,f}}) where {T,f} = Normed{T,f}(zero(T),0)
-function one(::Type{T}) where {T <: Normed}
+function oneunit(::Type{T}) where {T <: Normed}
     T(typemax(rawtype(T)) >> (8*sizeof(T)-nbitsfrac(T)), 0)
 end
+one(::Type{T}) where {T <: Normed} = oneunit(T)
 zero(x::Normed) = zero(typeof(x))
- one(x::Normed) =  one(typeof(x))
+oneunit(x::Normed) =  one(typeof(x))
+one(x::Normed) = oneunit(x)
 rawone(v) = reinterpret(one(v))
 
 # Conversions
@@ -68,7 +70,7 @@ function convert(::Type{T}, x::Normed) where {T <: AbstractFloat}
 end
 convert(::Type{Bool}, x::Normed) = x == zero(x) ? false : true
 convert(::Type{Integer}, x::Normed) = convert(Integer, x*1.0)
-convert(::Type{T}, x::Normed) where {T <: Integer} = convert(T, x*(1/one(T)))
+convert(::Type{T}, x::Normed) where {T <: Integer} = convert(T, x*(1/oneunit(T)))
 convert(::Type{Rational{Ti}}, x::Normed) where {Ti <: Integer} = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))
 convert(::Type{Rational}, x::Normed) = reinterpret(x)//rawone(x)
 
@@ -94,14 +96,14 @@ function round(x::Normed{T,f}) where {T,f}
     mask = convert(T, 1<<(f-1))
     y = trunc(x)
     return convert(T, reinterpret(x)-reinterpret(y)) & mask>0 ?
-            Normed{T,f}(y+one(Normed{T,f})) : y
+            Normed{T,f}(y+oneunit(Normed{T,f})) : y
 end
 function ceil(x::Normed{T,f}) where {T,f}
     k = 8*sizeof(T)-f
     mask = (typemax(T)<<k)>>k
     y = trunc(x)
     return convert(T, reinterpret(x)-reinterpret(y)) & (mask)>0 ?
-            Normed{T,f}(y+one(Normed{T,f})) : y
+            Normed{T,f}(y+oneunit(Normed{T,f})) : y
 end
 
 trunc(::Type{T}, x::Normed) where {T <: Integer} = convert(T, div(reinterpret(x), rawone(x)))


### PR DESCRIPTION
It's somewhat debatable what type one(T) should return but I decided to keep it the same type as it makes a certain amount of sense (and is definitely less breaking).