### PR TITLE
Prettier `summary` for Array{<:FixedPoint} using showarg

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -113,6 +113,15 @@ end
 const _log2_10 = 3.321928094887362
 showcompact(io::IO, x::FixedPoint{T,f}) where {T,f} = show(io, round(convert(Float64,x), ceil(Int,f/_log2_10)))
 
+if VERSION >= v"0.7.0-DEV.1790"
+    function Base.showarg(io::IO, a::Array{T}, toplevel) where {T<:FixedPoint}
+        toplevel || print(io, "::")
+        print(io, "Array{")
+        showtype(io, T)
+        print(io, ",$(ndims(a))}")
+        toplevel && print(io, " with eltype ", T)
+    end
+end
 
 include("fixed.jl")
 include("normed.jl")

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -304,3 +304,9 @@ end
 # Overflow with Float16
 @test N0f16(Float16(1.0)) === N0f16(1.0)
 @test Float16(1.0) % N0f16 === N0f16(1.0)
+
+if VERSION >= v"0.7.0-DEV.1790"
+    a = N0f8[0.2, 0.4]
+    @test summary(a) == "2-element Array{N0f8,1} with eltype FixedPointNumbers.Normed{UInt8,8}"
+    @test summary(view(a, 1:2)) == "2-element view(::Array{N0f8,1}, 1:2) with eltype FixedPointNumbers.Normed{UInt8,8}"
+end


### PR DESCRIPTION
Over the past 8 months ImageCore did some deliberate type piracy in order to prototype some new simplified `show` functionality. Now the core component of that is in Base, so it's time to migrate this into the respective packages.
