### PR TITLE
Prevent overflow when converting from Float16

### DIFF
--- a/test/normed.jl
+++ b/test/normed.jl
@@ -300,3 +300,7 @@ for T in (Normed{UInt8,8}, Normed{UInt8,6},
     @test isa(a, Array{T,2})
     @test size(a) == (3,5)
 end
+
+# Overflow with Float16
+@test N0f16(Float16(1.0)) === N0f16(1.0)
+@test Float16(1.0) % N0f16 === N0f16(1.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using FixedPointNumbers, Base.Test
 
+@test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))
+
 for f in ["normed.jl", "fixed.jl"]
     println("Testing $f")
     include(f)
 end
-
-@test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))


### PR DESCRIPTION
Ref https://discourse.julialang.org/t/saving-greater-than-8-bit-images/6057