### PR TITLE
avoid infinite loop in promote_rule

### DIFF
--- a/src/normed.jl
+++ b/src/normed.jl
@@ -159,7 +159,9 @@ end
     i1, i2 = 8*sizeof(T1)-f1, 8*sizeof(T2)-f2  # number of integer bits for each
     i = 8*sizeof(T)-f
     while i < max(i1, i2)
-        T = widen1(T)
+        Tw = widen1(T)
+        T == Tw && break
+        T = Tw
         i = 8*sizeof(T)-f
     end
     :(Normed{$T,$f})

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -262,6 +262,7 @@ end
 @test promote_type(Int,Float32,N0f8) == Float32
 @test promote_type(Float32,Int,N0f8) == Float32
 @test promote_type(Float32,N0f8,Int) == Float32
+@test promote_type(N0f8,N1f7,N2f6,N3f5,N4f4,N5f3) == Normed{UInt128,8}
 end
 
 @testset "show" begin


### PR DESCRIPTION
This change addresses a hang described in https://github.com/JuliaImages/ImageCore.jl/issues/64
Once the base type reaches `UInt128`, widening is an identity.

Suggestions for a good test are welcome.