### PR TITLE
implement promotion between Fixed types

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -69,6 +69,7 @@ widen1(::Type{Int32})  = Int64
 widen1(::Type{UInt32}) = UInt64
 widen1(::Type{Int64})  = Int128
 widen1(::Type{UInt64}) = UInt128
+widen1(::Type{Int128}) = Int128
 widen1(::Type{UInt128}) = UInt128
 widen1(x::Integer) = x % widen1(typeof(x))
 

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -45,6 +45,13 @@ abs(x::Fixed{T,f}) where {T,f} = Fixed{T,f}(abs(x.i),0)
 
 
 # # conversions and promotions
+function Fixed{T,f}(x::Fixed{T2,f2}) where {T <: Integer,T2 <: Integer,f,f2}
+#    reinterpret(Fixed{T,f},T(reinterpret(x)<<(f-f2)))
+    U = Fixed{T,f}
+    y = round(((1<<f)/(1<<f2))*reinterpret(x))
+    (typemin(T) <= y) & (y <= typemax(T)) || throw_converterror(U, x)
+    reinterpret(U, _unsafe_trunc(T, y))
+end
 
 rem(x::Integer, ::Type{Fixed{T,f}}) where {T,f} = Fixed{T,f}(rem(x,T)<<f,0)
 rem(x::Real,    ::Type{Fixed{T,f}}) where {T,f} = Fixed{T,f}(rem(Integer(trunc(x)),T)<<f + rem(Integer(round(rem(x,1)*(one(widen1(T))<<f))),T),0)
@@ -72,6 +79,21 @@ end
 promote_rule(ft::Type{Fixed{T,f}}, ::Type{TI}) where {T,f,TI <: Integer} = Fixed{T,f}
 promote_rule(::Type{Fixed{T,f}}, ::Type{TF}) where {T,f,TF <: AbstractFloat} = TF
 promote_rule(::Type{Fixed{T,f}}, ::Type{Rational{TR}}) where {T,f,TR} = Rational{TR}
+
+@generated function promote_rule(::Type{Fixed{T1,f1}}, ::Type{Fixed{T2,f2}}) where {T1,T2,f1,f2}
+    f = max(f1, f2)  # ensure we have enough precision
+    T = promote_type(T1, T2)
+    # make sure we have enough integer bits
+    i1, i2 = 8*sizeof(T1)-f1, 8*sizeof(T2)-f2  # number of integer bits for each
+    i = 8*sizeof(T)-f
+    while i < max(i1, i2)
+        Tw = widen1(T)
+        T == Tw && break
+        T = Tw
+        i = 8*sizeof(T)-f
+    end
+    :(Fixed{$T,$f})
+end
 
 # TODO: Document and check that it still does the right thing.
 decompose(x::Fixed{T,f}) where {T,f} = x.i, -f, 1

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -16,7 +16,7 @@ function test_fixed(::Type{T}, f) where {T}
         if !(typemin(T) < x <= typemax(T))
             continue
         end
-        isinteger(x) && @show x
+        # isinteger(x) && @show x
         fx = convert(T,x)
         @test convert(T,convert(Float64, fx)) == fx
         @test convert(T,convert(Float64, -fx)) == -fx
@@ -62,7 +62,7 @@ end
 @testset "test_fixed" begin
 for (TI, f) in [(Int8, 8), (Int16, 8), (Int16, 10), (Int32, 16)]
     T = Fixed{TI,f}
-    println("  Testing $T")
+    # println("  Testing $T")
     test_fixed(T, f)
 end
 end
@@ -165,5 +165,31 @@ for (T, f) in ((Int8, 7),
     for x in range(-1, stop=BigFloat(tmax)-tol, length=50)
         @test abs(Fixed{T, f}(x) - x) <= tol
     end
+end
+
+@testset "Promotion within Fixed" begin
+@test @inferred(promote(Q0f7(0.25), Q0f7(0.75))) ===
+    (Q0f7(0.25), Q0f7(0.75))
+@test @inferred(promote(Fixed{Int16,3}(0.25), Fixed{Int8,3}(0.875))) ===
+    (Fixed{Int16,3}(0.25), Fixed{Int16,3}(0.875))
+@test @inferred(promote(Fixed{Int8,6}(0.125), Fixed{Int8,4}(0.75))) ===
+    (Fixed{Int16,6}(0.125), Fixed{Int16,6}(0.75))
+
+@test Fixed{Int16,15}(-1)   == Fixed{Int8,7}(-1)
+@test Fixed{Int16,15}(0.25) == Fixed{Int8,7}(0.25)
+@test Fixed{Int16,7}(-1)   == Fixed{Int8,7}(-1)
+@test Fixed{Int16,7}(0.25) == Fixed{Int8,7}(0.25)
+@test Fixed{Int16,15}(-1)   == Fixed{Int8,5}(-1)
+@test Fixed{Int16,15}(5/32) == Fixed{Int8,5}(5/32)
+@test Fixed{Int16,3}(-1)   == Fixed{Int8,5}(-1)
+@test Fixed{Int16,3}(0.25) == Fixed{Int8,5}(0.25)
+
+@test promote_type(Q0f7,Float32,Int) == Float32
+@test promote_type(Q0f7,Int,Float32) == Float32
+@test promote_type(Int,Q0f7,Float32) == Float32
+@test promote_type(Int,Float32,Q0f7) == Float32
+@test promote_type(Float32,Int,Q0f7) == Float32
+@test promote_type(Float32,Q0f7,Int) == Float32
+@test promote_type(Q0f7,Q1f6,Q2f5,Q3f4,Q4f3,Q5f2) == Fixed{Int128,7}
 end
 end


### PR DESCRIPTION
Since @timholy pointed out in #113 that the promotion scheme for Normed should work for Fixed, it seems only fair to add the relevant methods.