### PR TITLE
Improve accuracy of conversions from floating-point numbers (Fixes #102)

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -15,7 +15,7 @@ import Base: ==, <, <=, -, +, *, /, ~, isapprox,
 using Base: @pure
 
 # T => BaseType
-# f => Number of Bytes reserved for fractional part
+# f => Number of bits reserved for fractional part
 abstract type FixedPoint{T <: Integer, f} <: Real end
 
 
@@ -25,7 +25,7 @@ export
     Normed,
     floattype,
 # "special" typealiases
-    # Q and U typealiases are exported in separate source files
+    # Q and N typealiases are exported in separate source files
 # Functions
     scaledual
 


### PR DESCRIPTION
This fixes a problem with the input range checking (#102).
Since this PR includes low-level operations, special attention is required. The additional tests are for range checking, not for accuracy or integrity.
This PR has little effect on the conversions to `Normed{UInt8}` and `Normed{UInt16}`.