### PR TITLE
Remove `testapprox` dependency and Reduce the number of test cases for display (#133)

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -84,8 +84,11 @@ end
 end
 
 @testset "testapprox" begin
-    for T in [Fixed{Int8,7}, Fixed{Int16,8}, Fixed{Int16,10}]
-        testapprox(T)  # defined in ufixed.jl
+    @testset "approx $T" for T in [Fixed{Int8,7}, Fixed{Int16,8}, Fixed{Int16,10}]
+        xs = typemin(T):eps(T):typemax(T)-eps(T)
+        @test all(x -> x ≈ x + eps(T), xs)
+        @test all(x -> x + eps(T) ≈ x, xs)
+        @test !any(x -> x - eps(T) ≈ x + eps(T), xs)
     end
 end
 

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -230,18 +230,12 @@ end
     end
 end
 
-function testapprox(::Type{T}) where {T}
-    for x = typemin(T):eps(T):typemax(T)-eps(T)
-        y = x+eps(T)
-        @test x ≈ y
-        @test y ≈ x
-        @test !(x ≈ y+eps(T))
-    end
-end
-
 @testset "approx" begin
-    for T in FixedPointNumbers.UF
-        testapprox(T)
+    @testset "approx $T" for T in FixedPointNumbers.UF
+        xs = typemin(T):eps(T):typemax(T)-eps(T)
+        @test all(x -> x ≈ x + eps(T), xs)
+        @test all(x -> x + eps(T) ≈ x, xs)
+        @test !any(x -> x - eps(T) ≈ x + eps(T), xs)
     end
 end
 


### PR DESCRIPTION
This fixes #133.
This does not change the actual test cases except one *wraparound* case, and also does not change `testtrunc`.