### PR TITLE
Fix `rem` problem with negative float inputs on ARMv7 (Fixes #134)

### DIFF
--- a/src/normed.jl
+++ b/src/normed.jl
@@ -203,3 +203,9 @@ end
 
 _unsafe_trunc(::Type{T}, x::Integer) where {T} = x % T
 _unsafe_trunc(::Type{T}, x) where {T}          = unsafe_trunc(T, x)
+if !signbit(signed(unsafe_trunc(UInt, -12.345)))
+    # a workaround for 32-bit ARMv7 (issue #134)
+    function _unsafe_trunc(::Type{T}, x::AbstractFloat) where {T}
+        unsafe_trunc(T, unsafe_trunc(typeof(signed(zero(T))), x))
+    end
+end


### PR DESCRIPTION
This fixes issue #134.