### PR TITLE
Precompile methods for common types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - osx
 julia:
     - 1.0
-    - 1.1
+    - 1.2
     - nightly
 notifications:
   email: false

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -1,5 +1,3 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 module FixedPointNumbers
 
 import Base: ==, <, <=, -, +, *, /, ~, isapprox,
@@ -198,5 +196,8 @@ end
 
 rand(::Type{T}) where {T <: FixedPoint} = reinterpret(T, rand(rawtype(T)))
 rand(::Type{T}, sz::Dims) where {T <: FixedPoint} = reinterpret(T, rand(rawtype(T), sz))
+
+include("precompile.jl")
+_precompile_()
 
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,30 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    normedtypes = (N0f8, N0f16)                      # precompiled Normed types
+    realtypes = (Float16, Float32, Float64, Int)     # types for mixed Normed/Real operations
+    for T in normedtypes
+        for f in (+, -, abs, eps, rand)       # unary operations
+            @assert precompile(Tuple{typeof(f),T})
+        end
+        @assert precompile(Tuple{typeof(rand),T,Tuple{Int}})
+        @assert precompile(Tuple{typeof(rand),T,Tuple{Int,Int}})
+        for f in (trunc, floor, ceil, round)  # rounding operations
+            @assert precompile(Tuple{typeof(f),T})
+            @assert precompile(Tuple{typeof(f),Type{Int},T})
+        end
+        for f in (+, -, *, /, <, <=, ==)      # binary operations
+            @assert precompile(Tuple{typeof(f),T,T})
+            for S in realtypes
+                @assert precompile(Tuple{typeof(f),T,S})
+                @assert precompile(Tuple{typeof(f),S,T})
+            end
+        end
+        # conversions
+        for S in realtypes
+            @assert precompile(Tuple{Type{T},S})
+            @assert precompile(Tuple{Type{S},T})
+            @assert precompile(Tuple{typeof(convert),Type{T},S})
+            @assert precompile(Tuple{typeof(convert),Type{S},T})
+        end
+    end
+end


### PR DESCRIPTION
This adds some precompile statements to reduce latency. Because the methods are simple to infer, the savings are modest, but combined with precompiles in other packages (ColorTypes, Colors, ColorVectorSpace) I'm getting latency reductions of ~30% for some common operations. So these seem worth having.
