### PR TITLE
Add rounding functions for `Fixed` (Fixes #153)

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -139,6 +139,15 @@ for f in (:+, :-, :rem, :mod, :mod1, :min, :max)
         $f(x::X, y::X) where {X <: FixedPoint} = X($f(x.i, y.i), 0)
     end
 end
+for (m, f) in ((:(:Nearest), :round),
+               (:(:ToZero), :trunc),
+               (:(:Up), :ceil),
+               (:(:Down), :floor))
+    @eval begin
+        round(x::FixedPoint, ::RoundingMode{$m}) = $f(x)
+        round(::Type{Ti}, x::FixedPoint, ::RoundingMode{$m}) where {Ti <: Integer} = $f(Ti, x)
+    end
+end
 
 # Printing. These are used to generate type-symbols, so we need them
 # before we include any files.

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -144,6 +144,16 @@ end
             @test_throws ArgumentError round(typemax(F) - F(0.5) + eps(F))
         end
     end
+    @testset "rounding mode" begin
+        @test round(-1.5Q1f6, RoundNearest) === -2Q1f6
+        @test round(-1.5Q1f6, RoundToZero) === -1Q1f6
+        @test round(-1.5Q1f6, RoundUp) === -1Q1f6
+        @test round(-1.5Q1f6, RoundDown) === -2Q1f6
+        @test round(Int, -1.5Q1f6, RoundNearest) === -2
+        @test round(Int, -1.5Q1f6, RoundToZero) === -1
+        @test round(Int, -1.5Q1f6, RoundUp) === -1
+        @test round(Int, -1.5Q1f6, RoundDown) === -2
+    end
     @test_throws InexactError trunc(UInt, typemin(Q0f7))
     @test_throws InexactError floor(UInt, -eps(Q0f7))
 end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -70,6 +70,18 @@ end
     @test reinterpret(Int8, 0.5Q0f7) === signed(0x40)
 end
 
+@testset "masks" begin
+    @test FixedPointNumbers.intmask(0Q7f0) === signed(0xFF)
+    @test FixedPointNumbers.intmask(0Q6f1) === signed(0xFE)
+    @test FixedPointNumbers.intmask(0Q1f6) === signed(0xC0)
+    @test FixedPointNumbers.intmask(0Q0f7) === signed(0x80)
+
+    @test FixedPointNumbers.fracmask(0Q7f0) === signed(0x00)
+    @test FixedPointNumbers.fracmask(0Q6f1) === signed(0x01)
+    @test FixedPointNumbers.fracmask(0Q1f6) === signed(0x3F)
+    @test FixedPointNumbers.fracmask(0Q0f7) === signed(0x7F)
+end
+
 @testset "inexactness" begin
     @test_throws InexactError Q0f7(-2)
     # TODO: change back to InexactError when it allows message strings
@@ -94,6 +106,46 @@ end
         # println("  Testing $T")
         test_fixed(T, f)
     end
+end
+
+@testset "rounding" begin
+    for T in (Int8, Int16, Int32, Int64)
+        rs = vcat([ oneunit(T) << b - oneunit(T) for b = 0:bitwidth(T)-1],
+                  [ oneunit(T) << b              for b = 1:bitwidth(T)-2],
+                  [ oneunit(T) << b + oneunit(T) for b = 2:bitwidth(T)-2],
+                  [-oneunit(T) << b - oneunit(T) for b = 2:bitwidth(T)-2],
+                  [-oneunit(T) << b              for b = 1:bitwidth(T)-1],
+                  [-oneunit(T) << b + oneunit(T) for b = 1:bitwidth(T)-1])
+        @testset "rounding Fixed{$T,$f}" for f = 0:bitwidth(T)-1
+            F = Fixed{T,f}
+            xs = (reinterpret(F, r) for r in rs)
+            @test all(x -> trunc(x) == trunc(float(x)), xs)
+            @test all(x -> floor(float(x)) < typemin(F) || floor(x) == floor(float(x)), xs)
+            @test all(x ->  ceil(float(x)) > typemax(F) ||  ceil(x) ==  ceil(float(x)), xs)
+            @test all(x -> round(float(x)) > typemax(F) || round(x) == round(float(x)), xs)
+            @test all(x -> trunc(Int64, x) === trunc(Int64, float(x)), xs)
+            @test all(x -> floor(Int64, x) === floor(Int64, float(x)), xs)
+            @test all(x ->  ceil(Int64, x) ===  ceil(Int64, float(x)), xs)
+            @test all(x -> round(Int64, x) === round(Int64, float(x)), xs)
+        end
+    end
+    @testset "rounding Fixed{Int16,$f} with overflow" for f = 1:16 # TODO: drop 16
+        F = Fixed{Int16,f}
+        @test_throws ArgumentError ceil(typemax(F))
+        if f == 16
+            @test_throws ArgumentError ceil(eps(F))
+        elseif f == 15
+            @test_throws ArgumentError ceil(eps(F))
+            @test_throws ArgumentError round(typemax(F))
+            @test_throws ArgumentError round(F(0.5) + eps(F))
+        else
+            @test_throws ArgumentError ceil(typemin(F) - oneunit(F) + eps(F))
+            @test_throws ArgumentError round(typemax(F))
+            @test_throws ArgumentError round(typemax(F) - F(0.5) + eps(F))
+        end
+    end
+    @test_throws InexactError trunc(UInt, typemin(Q0f7))
+    @test_throws InexactError floor(UInt, -eps(Q0f7))
 end
 
 @testset "modulus" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -264,6 +264,16 @@ end
         @test_throws ArgumentError ceil(typemax(N))
         @test_throws ArgumentError ceil(floor(typemax(N)) + eps(N))
     end
+    @testset "rounding mode" begin
+        @test round(1.504N1f7, RoundNearest) === 2N1f7
+        @test round(1.504N1f7, RoundToZero) === 1N1f7
+        @test round(1.504N1f7, RoundUp) === 2N1f7
+        @test round(1.504N1f7, RoundDown) === 1N1f7
+        @test round(Int, 1.504N1f7, RoundNearest) === 2
+        @test round(Int, 1.504N1f7, RoundToZero) === 1
+        @test round(Int, 1.504N1f7, RoundUp) === 2
+        @test round(Int, 1.504N1f7, RoundDown) === 1
+    end
 end
 
 @testset "approx" begin


### PR DESCRIPTION
This is a part of #151 and fixes #153.

succeeding PRs: this -> `isinteger`(#120) -> `rem`(#150) -> `Integer`(#154) -> `Rational`(#157)

**Edit:**
~Let's decide #159 first.~ Done.