### PR TITLE
Fix `isinteger`

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -62,7 +62,10 @@ function isapprox(x::FixedPoint, y::FixedPoint; rtol=0, atol=max(eps(x), eps(y))
 end
 
 # predicates
-isinteger(x::FixedPoint{T,f}) where {T,f} = (x.i&(1<<f-1)) == 0
+isinteger(x::FixedPoint) = x == trunc(x) # TODO: use floor(x) when dropping support for Fixed{Int8,8}
+isfinite(x::FixedPoint) = true
+isnan(x::FixedPoint) = false
+isinf(x::FixedPoint) = false
 
 # identities
 zero(::Type{X}) where {X <: FixedPoint} = X(zero(rawtype(X)), 0)

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -268,10 +268,6 @@ function round(::Type{Ti}, x::Normed) where {Ti <: Integer}
     convert(Ti, r > (rawone(x) >> 0x1) ? d + oneunit(rawtype(x)) : d)
 end
 
-isfinite(x::Normed) = true
-isnan(x::Normed) = false
-isinf(x::Normed) = false
-
 # Iteration
 # The main subtlety here is that iterating over N0f8(0):N0f8(1) will wrap around
 # unless we iterate using a wider type


### PR DESCRIPTION
This fixes the issue #120 by means of the commonized function `trunc`.

~This is for early feedback, so let's merge PR #163 first.~ Done.

Obviously this is slower than the method proposed in PR #123. However, I guess that `isinteger` is limitedly used, because the discovery of #120 was somewhat late and (parhaps) there was no need to rush to fix it. Even `Integer`, which is the rare use case of `isinteger`, is already broken (cf. https://github.com/JuliaMath/FixedPointNumbers.jl/issues/154#issuecomment-568896718).

The `trunc` is SIMD-suitable, so the slowdown is not fatal. FYI, `floor` may be faster but may throw errors in the cases of `Fixed{Int8,8}` and so on.