### PR TITLE
Improve accuracy of `rem` with `Normed` types (e.g. `::Float32 % N0f32`)

### DIFF
--- a/test/normed.jl
+++ b/test/normed.jl
@@ -200,6 +200,10 @@ end
 
     @test 1 % N0f8 == 1
     @test 2 % N0f8 == N0f8(0.996)
+
+    # issue #150
+    @test all(f -> 1.0f0 % Normed{UInt32,f} == oneunit(Normed{UInt32,f}), 1:32)
+    @test all(f -> 1.0e0 % Normed{UInt64,f} == oneunit(Normed{UInt64,f}), 1:64)
 end
 
 @testset "bitwise" begin


### PR DESCRIPTION
This fixes #150.

`Float32` and `Float64` versions can be unified, but the unified method may be difficult to read. So, I implemented them into two methods.
As I mentioned in https://github.com/JuliaMath/FixedPointNumbers.jl/issues/150#issuecomment-567035999, there are still numerical errors.