### PR TITLE
[RFC] Commonize further code between `Fixed` and` Normed`

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -45,7 +45,18 @@ nbitsfrac(::Type{X}) where {T, f, X <: FixedPoint{T,f}} = f
 rawtype(::Type{X}) where {T, X <: FixedPoint{T}} = T
 
 # construction using the (approximate) intended value, i.e., N0f8
-*(x::Real, ::Type{X}) where {X<:FixedPoint} = X(x)
+*(x::Real, ::Type{X}) where {X <: FixedPoint} = _convert(X, x)
+
+# constructor-style conversions
+(::Type{X})(x::Real) where {X <: FixedPoint} = _convert(X, x)
+
+function (::Type{<:FixedPoint})(x::AbstractChar)
+    throw(ArgumentError("FixedPoint (Fixed or Normed) cannot be constructed from a Char"))
+end
+(::Type{X})(x::Complex) where {X <: FixedPoint} = X(convert(real(typeof(x)), x))
+function (::Type{X})(x::Base.TwicePrecision) where {X <: FixedPoint}
+    floattype(X) === BigFloat ? X(big(x)) : X(convert(floattype(X), x))
+end
 
 # conversions
 function Base.Bool(x::FixedPoint)

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -55,6 +55,7 @@ function (::Type{Ti})(x::FixedPoint) where {Ti <: Integer}
     isinteger(x) || throw(InexactError(:Integer, typeof(x), x))
     floor(Ti, x)
 end
+Base.Rational{Ti}(x::FixedPoint) where {Ti <: Integer} = Rational{Ti}(Rational(x))
 
 """
     isapprox(x::FixedPoint, y::FixedPoint; rtol=0, atol=max(eps(x), eps(y)))

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -47,6 +47,15 @@ rawtype(::Type{X}) where {T, X <: FixedPoint{T}} = T
 # construction using the (approximate) intended value, i.e., N0f8
 *(x::Real, ::Type{X}) where {X<:FixedPoint} = X(x)
 
+# conversions
+function Base.Bool(x::FixedPoint)
+    x == zero(x) ? false : x == oneunit(x) ? true : throw(InexactError(:Bool, Bool, x))
+end
+function (::Type{Ti})(x::FixedPoint) where {Ti <: Integer}
+    isinteger(x) || throw(InexactError(:Integer, typeof(x), x))
+    floor(Ti, x)
+end
+
 """
     isapprox(x::FixedPoint, y::FixedPoint; rtol=0, atol=max(eps(x), eps(y)))
 

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -81,16 +81,6 @@ Base.BigFloat(x::Fixed{T,f}) where {T,f} =
 (::Type{TF})(x::Fixed{T,f}) where {TF <: AbstractFloat,T,f} =
     TF(x.i>>f) + TF(x.i&(one(widen1(T))<<f - 1))/TF(one(widen1(T))<<f)
 
-Base.Bool(x::Fixed{T,f}) where {T,f} = x.i!=0
-function Base.Integer(x::Fixed{T,f}) where {T,f}
-    isinteger(x) || throw(InexactError())
-    Integer(x.i>>f)
-end
-function (::Type{TI})(x::Fixed{T,f}) where {TI <: Integer,T,f}
-    isinteger(x) || throw(InexactError())
-    TI(x.i>>f)
-end
-
 (::Type{TR})(x::Fixed{T,f}) where {TR <: Rational,T,f} =
     TR(x.i>>f + (x.i&(1<<f-1))//(one(widen1(T))<<f))
 

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -24,13 +24,6 @@ struct Fixed{T <: Signed, f} <: FixedPoint{T, f}
     end
 end
 
-Fixed{T, f}(x::AbstractChar) where {T,f} = throw(ArgumentError("Fixed cannot be constructed from a Char"))
-Fixed{T, f}(x::Complex) where {T,f} = Fixed{T, f}(convert(real(typeof(x)), x))
-Fixed{T, f}(x::Base.TwicePrecision) where {T,f} = Fixed{T, f}(convert(Float64, x))
-Fixed{T,f}(x::Integer) where {T,f} = Fixed{T,f}(round(T, convert(widen1(T),x)<<f),0)
-Fixed{T,f}(x::AbstractFloat) where {T,f} = Fixed{T,f}(round(T, trunc(widen1(T),x)<<f + rem(x,1)*(one(widen1(T))<<f)),0)
-Fixed{T,f}(x::Rational) where {T,f} = Fixed{T,f}(x.num)/Fixed{T,f}(x.den)
-
 typechar(::Type{X}) where {X <: Fixed} = 'Q'
 signbits(::Type{X}) where {X <: Fixed} = 1
 
@@ -53,6 +46,25 @@ end
 intmask(::Fixed{T,f}) where {T, f} = -oneunit(T) << f # Signed
 fracmask(x::Fixed{T,f}) where {T, f} = ~intmask(x) # Signed
 
+# constructor-style conversions
+function _convert(::Type{F}, x::Fixed{T2,f2}) where {T, T2, f, f2, F <: Fixed{T,f}}
+    y = round(((1<<f)/(1<<f2))*reinterpret(x)) # FIXME: avoid overflow
+    (typemin(T) <= y) & (y <= typemax(T)) || throw_converterror(F, x)
+    reinterpret(F, _unsafe_trunc(T, y))
+end
+
+function _convert(::Type{F}, x::Integer) where {T, f, F <: Fixed{T,f}}
+    reinterpret(F, round(T, convert(widen1(T),x)<<f)) # TODO: optimization and input range checking
+end
+
+function _convert(::Type{F}, x::AbstractFloat) where {T, f, F <: Fixed{T,f}}
+    reinterpret(F, round(T, trunc(widen1(T),x)<<f + rem(x,1)*(one(widen1(T))<<f))) # TODO: optimization and input range checking
+end
+
+function _convert(::Type{F}, x::Rational) where {T, f, F <: Fixed{T,f}}
+    F(x.num)/F(x.den) # TODO: optimization and input range checking
+end
+
 # unchecked arithmetic
 
 # with truncation:
@@ -62,15 +74,6 @@ fracmask(x::Fixed{T,f}) where {T, f} = ~intmask(x) # Signed
 
 /(x::Fixed{T,f}, y::Fixed{T,f}) where {T,f} = Fixed{T,f}(div(convert(widen(T), x.i) << f, y.i), 0)
 
-
-# # conversions and promotions
-function Fixed{T,f}(x::Fixed{T2,f2}) where {T <: Integer,T2 <: Integer,f,f2}
-#    reinterpret(Fixed{T,f},T(reinterpret(x)<<(f-f2)))
-    U = Fixed{T,f}
-    y = round(((1<<f)/(1<<f2))*reinterpret(x))
-    (typemin(T) <= y) & (y <= typemax(T)) || throw_converterror(U, x)
-    reinterpret(U, _unsafe_trunc(T, y))
-end
 
 rem(x::Integer, ::Type{Fixed{T,f}}) where {T,f} = Fixed{T,f}(rem(x,T)<<f,0)
 rem(x::Real,    ::Type{Fixed{T,f}}) where {T,f} = Fixed{T,f}(rem(Integer(trunc(x)),T)<<f + rem(Integer(round(rem(x,1)*(one(widen1(T))<<f))),T),0)

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -81,8 +81,9 @@ Base.BigFloat(x::Fixed{T,f}) where {T,f} =
 (::Type{TF})(x::Fixed{T,f}) where {TF <: AbstractFloat,T,f} =
     TF(x.i>>f) + TF(x.i&(one(widen1(T))<<f - 1))/TF(one(widen1(T))<<f)
 
-(::Type{TR})(x::Fixed{T,f}) where {TR <: Rational,T,f} =
-    TR(x.i>>f + (x.i&(1<<f-1))//(one(widen1(T))<<f))
+function Base.Rational(x::Fixed{T,f}) where {T, f}
+    f < bitwidth(T)-1 ? x.i//rawone(x) : x.i//(one(widen1(T))<<f)
+end
 
 function trunc(x::Fixed{T,f}) where {T, f}
     f == 0 && return x

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -239,9 +239,6 @@ end
 
 Base.BigFloat(x::Normed) = reinterpret(x)*(1/BigFloat(rawone(x)))
 
-Base.Bool(x::Normed) = x == zero(x) ? false : true
-Base.Integer(x::Normed) = convert(Integer, x*1.0)
-(::Type{T})(x::Normed) where {T <: Integer} = convert(T, x*(1/oneunit(T)))
 Base.Rational{Ti}(x::Normed) where {Ti <: Integer} = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))
 Base.Rational(x::Normed) = reinterpret(x)//rawone(x)
 

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -239,7 +239,6 @@ end
 
 Base.BigFloat(x::Normed) = reinterpret(x)*(1/BigFloat(rawone(x)))
 
-Base.Rational{Ti}(x::Normed) where {Ti <: Integer} = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))
 Base.Rational(x::Normed) = reinterpret(x)//rawone(x)
 
 abs(x::Normed) = x

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -97,6 +97,11 @@ end
     @test_throws InexactError convert(Fixed{Int8, 7}, 1)
     @test_throws InexactError convert(Fixed{Int8, 7}, 2)
     @test_throws InexactError convert(Fixed{Int8, 7}, 128)
+
+    @test convert(Q2f5, -1//2) === -0.5Q2f5
+    @test_broken convert(Q1f6, Rational{Int8}(-3//4)) === -0.75Q1f6
+    @test_broken convert(Q0f7, Rational{Int16}(-3//4)) === -0.75Q0f7
+    @test_broken convert(Q0f7, Rational{UInt8}(3//4)) === 0.75Q0f7
 end
 
 @testset "test_fixed" begin
@@ -245,6 +250,12 @@ end
     @test convert(UInt, 1Q1f6) === UInt(1)
     @test_throws InexactError convert(Integer, 0.5Q1f6)
     @test_throws InexactError convert(Int8, 256Q9f6)
+end
+
+@testset "rational conversions" begin
+    @test convert(Rational, -0.75Q1f6) === Rational{Int8}(-3//4)
+    @test convert(Rational, -0.75Q0f7) === Rational{Int16}(-3//4)
+    @test convert(Rational{Int}, -0.75Q0f7) === Rational(-3//4)
 end
 
 @testset "Floating-point conversions" begin

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -102,6 +102,11 @@ end
     @test_broken convert(Q1f6, Rational{Int8}(-3//4)) === -0.75Q1f6
     @test_broken convert(Q0f7, Rational{Int16}(-3//4)) === -0.75Q0f7
     @test_broken convert(Q0f7, Rational{UInt8}(3//4)) === 0.75Q0f7
+
+    @test convert(Q0f7, Base.TwicePrecision(0.5)) === 0.5Q0f7
+    @test_throws InexactError convert(Q7f8, Base.TwicePrecision(0x80, 0x01))
+    tp = Base.TwicePrecision(0xFFFFFFFFp-32, 0xFFFFFFFEp-64)
+    @test convert(Q0f63, tp) === reinterpret(Q0f63, typemax(Int64))
 end
 
 @testset "test_fixed" begin

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -231,9 +231,20 @@ end
     end
 end
 
+@testset "bool conversions" begin
+    @test convert(Bool, 0.0Q1f6) === false
+    @test convert(Bool, 1.0Q1f6) === true
+    @test_throws InexactError convert(Bool, 0.5Q1f6)
+    @test_throws InexactError convert(Bool, -1Q1f6)
+    @test_broken convert(Bool, Fixed{Int8,8}(0.2)) # TODO: remove this
+end
+
 @testset "Integer conversions" begin
     @test convert(Int, Q1f6(1)) === 1
     @test convert(Integer, Q1f6(1)) === Int8(1)
+    @test convert(UInt, 1Q1f6) === UInt(1)
+    @test_throws InexactError convert(Integer, 0.5Q1f6)
+    @test_throws InexactError convert(Int8, 256Q9f6)
 end
 
 @testset "Floating-point conversions" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -92,6 +92,10 @@ end
 
     @test convert(N0f8,  1.1f0/typemax(UInt8)) == eps(N0f8)
 
+    @test_broken convert(N0f8, 1//255) === eps(N0f8)
+    @test_broken convert(N0f8, Rational{Int8}(3//5)) === N0f8(3/5)
+    @test_broken convert(N0f8, Rational{UInt8}(3//5)) === N0f8(3/5)
+
     @test convert(Float64, eps(N0f8)) == 1/typemax(UInt8)
     @test convert(Float32, eps(N0f8)) == 1.0f0/typemax(UInt8)
     @test convert(BigFloat, eps(N0f8)) == BigFloat(1)/typemax(UInt8)

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -98,7 +98,7 @@ end
     for T in (FixedPointNumbers.UF..., UF2...)
         @test convert(Bool, zero(T)) == false
         @test convert(Bool, one(T))  == true
-        @test convert(Bool, convert(T, 0.2)) == true
+        @test_throws InexactError convert(Bool, convert(T, 0.2))
         @test convert(Int, one(T)) == 1
         @test convert(Integer, one(T)) == 1
         @test convert(Rational, one(T)) == 1
@@ -107,6 +107,14 @@ end
     @test convert(N0f16, one(N0f8)) === one(N0f16)
     @test convert(N0f16, N0f8(0.5)).i === 0x8080
     @test convert(Normed{UInt16,7}, Normed{UInt8,7}(0.504)) === Normed{UInt16,7}(0.504)
+end
+
+@testset "integer conversions" begin
+    @test convert(UInt, 1N1f7) === UInt(1)
+    @test convert(Integer, 1N1f7) === 0x01
+    @test convert(Int, 1N1f7) === 1
+    @test_throws InexactError convert(Integer, 0.5N1f7)
+    @test_throws InexactError convert(Int8, 256N8f8)
 end
 
 @testset "conversion from float" begin


### PR DESCRIPTION
These commits fix #154 and commonize:
- `Bool` and `Integer` conversions
- `Rational` conversions
- constructor-style conversions

This PR introduces some breaking changes:
- `Bool` throws the InexactError for the inputs other than zero/one.
- The return type of `Integer(::Normed{T})` is now `T`.
- `Integer(::Fixed)` throws the InexactError instead of MethodError.
- The return type of `Rational(::FixedPoint{T})` is now `Rational{T}`, except `Fixed{Int8,8}`, `Q0f7`, `Q0f15` and so on.