### PR TITLE
Add support for `Normed` construction from `Rational` (Fixes #157)

### DIFF
--- a/src/normed.jl
+++ b/src/normed.jl
@@ -100,6 +100,14 @@ function _convert(::Type{N}, x::Tf) where {T, f, N <: Normed{T,f}, Tf <: Union{F
     return reinterpret(N, unsafe_trunc(T, yi >> (ex & bits)))
 end
 
+function _convert(::Type{N}, x::Rational) where {T, f, N <: Normed{T,f}}
+    if 0 <= x <= Rational(typemax(N))
+        reinterpret(N, round(T, convert(floattype(T), x) * rawone(N)))
+    else
+        throw_converterror(N, x)
+    end
+end
+
 rem(x::N, ::Type{N}) where {N <: Normed} = x
 rem(x::Normed, ::Type{N}) where {T, N <: Normed{T}} = reinterpret(N, _unsafe_trunc(T, round((rawone(N)/rawone(x))*reinterpret(x))))
 rem(x::Real, ::Type{N}) where {T, N <: Normed{T}} = reinterpret(N, _unsafe_trunc(T, round(rawone(N)*x)))

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -99,9 +99,10 @@ end
     @test_throws InexactError convert(Fixed{Int8, 7}, 128)
 
     @test convert(Q2f5, -1//2) === -0.5Q2f5
-    @test_broken convert(Q1f6, Rational{Int8}(-3//4)) === -0.75Q1f6
-    @test_broken convert(Q0f7, Rational{Int16}(-3//4)) === -0.75Q0f7
-    @test_broken convert(Q0f7, Rational{UInt8}(3//4)) === 0.75Q0f7
+    @test convert(Q1f6, Rational{Int8}(-3//4)) === -0.75Q1f6
+    @test convert(Q0f7, Rational{Int16}(-3//4)) === -0.75Q0f7
+    @test convert(Q0f7, Rational{UInt8}(3//4)) === 0.75Q0f7
+    @test_throws ArgumentError convert(Q0f7, typemax(Rational{Int8}))
 
     @test convert(Q0f7, Base.TwicePrecision(0.5)) === 0.5Q0f7
     @test_throws InexactError convert(Q7f8, Base.TwicePrecision(0x80, 0x01))

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -92,9 +92,10 @@ end
 
     @test convert(N0f8,  1.1f0/typemax(UInt8)) == eps(N0f8)
 
-    @test_broken convert(N0f8, 1//255) === eps(N0f8)
-    @test_broken convert(N0f8, Rational{Int8}(3//5)) === N0f8(3/5)
-    @test_broken convert(N0f8, Rational{UInt8}(3//5)) === N0f8(3/5)
+    @test convert(N0f8, 1//255) === eps(N0f8)
+    @test convert(N0f8, Rational{Int8}(3//5)) === N0f8(3/5)
+    @test convert(N0f8, Rational{UInt8}(3//5)) === N0f8(3/5)
+    @test_throws ArgumentError convert(N0f8, typemax(Rational{UInt8}))
 
     @test convert(N0f8, Base.TwicePrecision(1.0)) === 1N0f8
 


### PR DESCRIPTION
This also fixes the overflow problem with `Fixed` construction from `Rational`. (Fixes #157)

Note the input range that `Fixed` allows (cf. issue #156).