### PR TITLE
Modify Fixed constructors

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -82,8 +82,8 @@ end
 end
 
 @testset "inexactness" begin
-    @test_throws InexactError Q0f7(-2)
     # TODO: change back to InexactError when it allows message strings
+    @test_throws ArgumentError Q0f7(-2)
     @test_throws ArgumentError one(Q0f15)
     @test_throws ArgumentError oneunit(Q0f31)
     @test_throws ArgumentError one(Fixed{Int8,8}) # TODO: remove this at end of its support
@@ -92,11 +92,19 @@ end
 @testset "conversion" begin
     @test isapprox(convert(Fixed{Int8,7}, 0.8), 0.797, atol=0.001)
     @test isapprox(convert(Fixed{Int8,7}, 0.9), 0.898, atol=0.001)
-    @test_throws InexactError convert(Fixed{Int8, 7}, 0.999)
-    @test_throws InexactError convert(Fixed{Int8, 7}, 1.0)
-    @test_throws InexactError convert(Fixed{Int8, 7}, 1)
-    @test_throws InexactError convert(Fixed{Int8, 7}, 2)
-    @test_throws InexactError convert(Fixed{Int8, 7}, 128)
+    @test_throws ArgumentError convert(Fixed{Int8, 7}, 0.999)
+    @test_throws ArgumentError convert(Fixed{Int8, 7}, 1.0)
+    @test_throws ArgumentError convert(Fixed{Int8, 7}, 1)
+    @test_throws ArgumentError convert(Fixed{Int8, 7}, 2)
+    @test_throws ArgumentError convert(Fixed{Int8, 7}, 128)
+    @test_throws ArgumentError convert(Fixed{Int8, 7}, 1.0)
+
+    @test convert(Q0f7, -128.5/128) == -1
+
+    @test convert(Q0f7, -0.75f0) == -0.75
+    @test convert(Q0f7, Float16(-0.75)) == -0.75
+    @test convert(Q0f7, BigFloat(-0.75)) == -0.75
+    @test_throws ArgumentError convert(Q0f7, BigFloat(127.5/128))
 
     @test convert(Q2f5, -1//2) === -0.5Q2f5
     @test convert(Q1f6, Rational{Int8}(-3//4)) === -0.75Q1f6
@@ -105,7 +113,7 @@ end
     @test_throws ArgumentError convert(Q0f7, typemax(Rational{Int8}))
 
     @test convert(Q0f7, Base.TwicePrecision(0.5)) === 0.5Q0f7
-    @test_throws InexactError convert(Q7f8, Base.TwicePrecision(0x80, 0x01))
+    @test_throws ArgumentError convert(Q7f8, Base.TwicePrecision(0x80, 0x01))
     tp = Base.TwicePrecision(0xFFFFFFFFp-32, 0xFFFFFFFEp-64)
     @test convert(Q0f63, tp) === reinterpret(Q0f63, typemax(Int64))
 end


### PR DESCRIPTION
This adds explicit input range checks. As a result, the constructors throw `ArgumentError` instead of `InexactError` for out-of-range inputs.