### PR TITLE
Version 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - osx
 julia:
     - 1.0
-    - 1.2
+    - 1
     - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedPointNumbers"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.7.0"
+version = "0.8.0"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
I'm ready to release v0.8.0. Is there anything left to do?

Julia v1.4.0-rc1 has been released and the nightly has been switched to v1.5 series, so I think it's time to check with v1.3 on Travis CI. Because FixedPointNumbers is a low-level package, explicit specification of the versions is not bad. However, from the viewpoint of reducing the trouble of updating, I would like to set it to `1` instead of `1.3`.

**Edit:**
This release contains some breaking changes. Perhaps the biggest impact for end users is the change of the conversion to `Bool`(cf. PR #168). These breaking changes might not be apparent in the tests of downstream packages. So, please check the compatibility carefully.