### PR TITLE
Fix reductions in Statistics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,9 @@ name = "FixedPointNumbers"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.1"
 
+[deps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
 [compat]
 julia = "1"
 

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -8,6 +8,8 @@ import Base: ==, <, <=, -, +, *, /, ~, isapprox,
              div, fld, rem, mod, mod1, fld1, min, max, minmax,
              rand, length
 
+import Statistics: _mean_promote
+
 using Base.Checked: checked_add, checked_sub, checked_div
 
 using Base: @pure
@@ -225,6 +227,7 @@ Base.mul_prod(x::FixedPoint, y::FixedPoint) = Treduce(x) * Treduce(y)
 Base.reduce_empty(::typeof(Base.mul_prod), ::Type{F}) where {F<:FixedPoint} = one(Treduce)
 Base.reduce_first(::typeof(Base.mul_prod), x::FixedPoint)  = Treduce(x)
 
+_mean_promote(x::Real, y::FixedPoint) = Treduce(y)
 
 """
     sd, ad = scaledual(s::Number, a)

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -8,7 +8,7 @@ import Base: ==, <, <=, -, +, *, /, ~, isapprox,
              div, fld, rem, mod, mod1, fld1, min, max, minmax,
              rand, length
 
-import Statistics: _mean_promote
+import Statistics   # for _mean_promote
 
 using Base.Checked: checked_add, checked_sub, checked_div
 
@@ -227,7 +227,9 @@ Base.mul_prod(x::FixedPoint, y::FixedPoint) = Treduce(x) * Treduce(y)
 Base.reduce_empty(::typeof(Base.mul_prod), ::Type{F}) where {F<:FixedPoint} = one(Treduce)
 Base.reduce_first(::typeof(Base.mul_prod), x::FixedPoint)  = Treduce(x)
 
-_mean_promote(x::Real, y::FixedPoint) = Treduce(y)
+if isdefined(Statistics, :_mean_promote)
+    Statistics._mean_promote(x::Real, y::FixedPoint) = Treduce(y)
+end
 
 """
     sd, ad = scaledual(s::Number, a)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Test
+using FixedPointNumbers, Statistics, Test
 using FixedPointNumbers: bitwidth
 
 function test_op(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol) where {F,T}
@@ -240,6 +240,17 @@ end
     acmp = Float64(a[1])*Float64(a[2])
     @test prod(a) == acmp
     @test prod(a, dims=1) == [acmp]
+end
+
+@testset "reductions, Statistics" begin
+    a = Q1f6[0.75, 0.5]
+    af = FixedPointNumbers.Treduce.(a)
+    @test mean(a) === mean(af)
+    @test std(a)  === std(af)
+    @test var(a)  === var(af)
+    m = mean(a)
+    @test stdm(a, m) === stdm(af, m)
+    @test varm(a, m) === varm(af, m)
 end
 
 @testset "convert result type" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Test
+using FixedPointNumbers, Statistics, Test
 using FixedPointNumbers: bitwidth
 
 @testset "domain of f" begin
@@ -447,6 +447,17 @@ end
     acmp = Float64(a[1])*Float64(a[2])
     @test prod(a) == acmp
     @test prod(a, dims=1) == [acmp]
+end
+
+@testset "reductions, Statistics" begin
+    a = N0f8[reinterpret(N0f8, 0x80), reinterpret(N0f8, 0x40)]
+    af = FixedPointNumbers.Treduce.(a)
+    @test mean(a) === mean(af)
+    @test std(a)  === std(af)
+    @test var(a)  === var(af)
+    m = mean(a)
+    @test stdm(a, m) === stdm(af, m)
+    @test varm(a, m) === varm(af, m)
 end
 
 @testset "rand" begin


### PR DESCRIPTION
Formerly we were choosing an inconsistent eltype for reductions performed by Statistics. Since that's a stdlib that comes for "free," it seems we should support it on similar footing to `reduce` etc.