### PR TITLE
Specialize sign-related functions

### DIFF
--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -25,7 +25,6 @@ struct Fixed{T <: Signed, f} <: FixedPoint{T, f}
 end
 
 typechar(::Type{X}) where {X <: Fixed} = 'Q'
-signbits(::Type{X}) where {X <: Fixed} = 1
 
 for T in (Int8, Int16, Int32, Int64)
     io = IOBuffer()

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -20,7 +20,6 @@ struct Normed{T <: Unsigned, f} <: FixedPoint{T, f}
 end
 
 typechar(::Type{X}) where {X <: Normed} = 'N'
-signbits(::Type{X}) where {X <: Normed} = 0
 
 for T in (UInt8, UInt16, UInt32, UInt64)
     io = IOBuffer()
@@ -247,8 +246,6 @@ end
 Base.BigFloat(x::Normed) = reinterpret(x) / BigFloat(rawone(x))
 
 Base.Rational(x::Normed) = reinterpret(x)//rawone(x)
-
-abs(x::Normed) = x
 
 # unchecked arithmetic
 *(x::T, y::T) where {T <: Normed} = convert(T,convert(floattype(T), x)*convert(floattype(T), y))

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -419,6 +419,23 @@ end
     @test clamp(1.5Q1f6, Q0f7) === 0.992Q0f7
 end
 
+@testset "sign-related functions" begin
+    @test_throws Exception signed(Q0f7)
+    @test_throws Exception signed(0.5Q0f7)
+    @test_throws Exception unsigned(Q0f7)
+    @test_throws Exception unsigned(0.5Q0f7)
+    @test copysign(0.5Q0f7, 0x1) === 0.5Q0f7
+    @test copysign(0.5Q0f7, -1) === -0.5Q0f7
+    @test flipsign(0.5Q0f7, 0x1) === 0.5Q0f7
+    @test flipsign(0.5Q0f7, -1) === -0.5Q0f7
+    @test_throws ArgumentError sign(0Q0f7)
+    @test sign(0Q1f6) === 0Q1f6
+    @test sign(0.5Q1f6) === 1Q1f6
+    @test sign(-0.5Q1f6) === -1Q1f6
+    @test signbit(0.5Q0f7) === false
+    @test signbit(-0.5Q0f7) === true
+end
+
 @testset "Promotion within Fixed" begin
     @test @inferred(promote(Q0f7(0.25), Q0f7(0.75))) ===
         (Q0f7(0.25), Q0f7(0.75))

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -351,6 +351,19 @@ end
     @test clamp(2.0N1f7, N0f8) === 1.0N0f8
 end
 
+@testset "sign-related functions" begin
+    @test_throws Exception signed(N0f8)
+    @test_throws Exception signed(1N0f8)
+    @test_throws Exception unsigned(N0f8)
+    @test_throws Exception unsigned(1N0f8)
+    @test_throws ArgumentError copysign(1N0f8, 0x1)
+    @test_throws ArgumentError copysign(1N0f8, -1)
+    @test_throws ArgumentError flipsign(1N0f8, 0x1)
+    @test_throws ArgumentError flipsign(1N0f8, -1)
+    @test_throws ArgumentError sign(0N0f8)
+    @test signbit(1N0f8) === false
+end
+
 @testset "unit range" begin
     @test length(N0f8(0):N0f8(1)) == 2
     @test length(N0f8(1):N0f8(0)) == 0


### PR DESCRIPTION
This is part of the issue #185.
**Edit:**
This prohibits `copysign`/`flipsign` for `Normed`. They should be confusing when the signed `Normed` is supported in the future. Furthermore, if signed `Normed` is available, we should not do unsafe sign operations for unsigned `Normed`.