### PR TITLE
Improve consistency in printing

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -49,6 +49,7 @@ rawtype(::Type{X}) where {T, X <: FixedPoint{T}} = T
 
 # traits based on static parameters
 signbits(::Type{X}) where {T, X <: FixedPoint{T}} = T <: Unsigned ? 0 : 1
+nbitsint(::Type{X}) where {X <: FixedPoint} = bitwidth(X) - nbitsfrac(X) - signbits(X)
 
 # construction using the (approximate) intended value, i.e., N0f8
 *(x::Real, ::Type{X}) where {X <: FixedPoint} = _convert(X, x)
@@ -260,27 +261,49 @@ function length(r::StepRange{<:FixedPoint})
     return div((stop - start) + step, step)
 end
 
+hasalias(::Type) = false
+hasalias(::Type{X}) where {T<:NotBiggerThanInt64, f, X<:FixedPoint{T,f}} = f isa Int
+
 # Printing. These are used to generate type-symbols, so we need them
-# before we include any files.
-function showtype(io::IO, ::Type{X}) where {X <: FixedPoint}
-    print(io, typechar(X))
-    f = nbitsfrac(X)
-    m = bitwidth(X)-f-signbits(X)
-    print(io, m, 'f', f)
+# before we include "src/fixed.jl" / "src/normed.jl".
+@inline function showtype(io::IO, ::Type{X}) where {X <: FixedPoint}
+    if hasalias(X)
+        f = nbitsfrac(X)
+        m = nbitsint(X)
+        write(io, typechar(X))
+        m > 9 && write(io, Char(m ÷ 10 + 0x30))
+        write(io, Char(m % 10 + 0x30), 'f')
+        f > 9 && write(io, Char(f ÷ 10 + 0x30))
+        write(io, Char(f % 10 + 0x30))
+    else
+        print(io, X)
+    end
     io
 end
+
 function show(io::IO, x::FixedPoint{T,f}) where {T,f}
+    compact = get(io, :compact, false)::Bool
     log10_2 = 0.3010299956639812
-    show(io, round(convert(Float64,x), digits=ceil(Int, f * log10_2)))
-    get(io, :compact, false) || showtype(io, typeof(x))
+    digits = min(ceil(Int, f * log10_2), compact ? 6 : typemax(Int))
+    val = round(convert(Float64, x), digits=digits)
+    if compact || get(io, :typeinfo, Any) === typeof(x)
+        show(io, val)
+    elseif hasalias(typeof(x))
+        show(io, val)
+        showtype(io, typeof(x))
+    else
+        print(io, typeof(x), '(', val, ')')
+    end
 end
 
-function Base.showarg(io::IO, a::Array{T}, toplevel) where {T<:FixedPoint}
-    toplevel || print(io, "::")
-    print(io, "Array{")
-    showtype(io, T)
-    print(io, ",$(ndims(a))}")
-    toplevel && print(io, " with eltype ", T)
+if VERSION < v"1.6.0-DEV.356"
+    function Base.showarg(io::IO, a::Array{X}, toplevel) where {X<:FixedPoint}
+        toplevel || print(io, "::")
+        print(io, "Array{")
+        showtype(io, X)
+        print(io, ",$(ndims(a))}")
+        toplevel && hasalias(X) && print(io, " with eltype ", X)
+    end
 end
 
 include("fixed.jl")

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -24,6 +24,9 @@ struct Fixed{T <: Signed, f} <: FixedPoint{T, f}
     end
 end
 
+# TODO: remove this
+hasalias(::Type{F}) where {F <: Union{Fixed{Int8,8},Fixed{Int16,16},Fixed{Int32,32},Fixed{Int64,64}}} = false
+
 typechar(::Type{X}) where {X <: Fixed} = 'Q'
 
 for T in (Int8, Int16, Int32, Int64)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -20,6 +20,7 @@ const LongInts = Union{Int64, UInt64, Int128, UInt128, BigInt}
 
 const ShorterThanInt = Int === Int32 ? ShortInts : Union{ShortInts, Int32, UInt32}
 const NotBiggerThanInt = Union{ShorterThanInt, Int, UInt}
+const NotBiggerThanInt64 = Union{ShortInts, Int32, UInt32, Int64, UInt64}
 const SShorterThanInt = typeintersect(ShorterThanInt, Signed)
 const UShorterThanInt = typeintersect(ShorterThanInt, Unsigned)
 

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -486,17 +486,17 @@ end
     @test String(take!(iob)) == "-21845.3"
 
     show(IOContext(iob, :typeinfo=>Q15f16), q15f16)
-    @test String(take!(iob)) == "-21845.33334Q15f16" # TODO: Consider removing suffix (issue #188)
+    @test String(take!(iob)) == "-21845.33334"
 
     show(IOContext(iob, :typeinfo=>Normed), q15f16)
     @test String(take!(iob)) == "-21845.33334Q15f16"
 
     show(iob, Fixed{Int128,64}(-1.2345e6))
-    @test_broken String(take!(iob)) == "Fixed{Int128,64}(-1.2345e6)" # "Q63f64" is not defined
+    @test String(take!(iob)) == "Fixed{Int128,64}(-1.2345e6)"
 
     # TODO: remove this test
     show(iob, reinterpret(Fixed{Int8,8}, signed(0xaa)))
-    @test_broken String(take!(iob)) == "Fixed{Int8,8}(-0.336)" # "Q-1f8" is invalid
+    @test String(take!(iob)) == "Fixed{Int8,8}(-0.336)"
 end
 
 @testset "summary" begin
@@ -504,12 +504,12 @@ end
     aa = Fixed[0.2Q0f7 0.4Q0f15]
 
     if VERSION >= v"1.6.0-DEV.356"
-        @test_broken summary(a) == "2-element Vector{Q0f7}"
-        @test_broken summary(view(a, 1:2)) == "2-element view(::Vector{Q0f7}, 1:2) with eltype Q0f7"
-        @test_broken summary(aa) == "1×2 Matrix{Fixed}"
+        @test summary(a) == "2-element Vector{Q0f7}"
+        @test summary(view(a, 1:2)) == "2-element view(::Vector{Q0f7}, 1:2) with eltype Q0f7"
+        @test summary(aa) == "1×2 Matrix{Fixed}"
     else
         @test summary(a) == "2-element Array{Q0f7,1} with eltype Fixed{Int8,7}"
         @test summary(view(a, 1:2)) == "2-element view(::Array{Q0f7,1}, 1:2) with eltype Fixed{Int8,7}"
-        @test_broken summary(aa) == "1×2 Array{Fixed,2}"
+        @test summary(aa) == "1×2 Array{Fixed,2}"
     end
 end

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -473,13 +473,13 @@ end
     @test String(take!(iob)) == "43691.3"
 
     show(IOContext(iob, :typeinfo=>N16f16), n16f16)
-    @test String(take!(iob)) == "43691.33333N16f16" # TODO: Consider removing suffix (issue #188)
+    @test String(take!(iob)) == "43691.33333"
 
     show(IOContext(iob, :typeinfo=>Normed), n16f16)
     @test String(take!(iob)) == "43691.33333N16f16"
 
     show(iob, Normed{UInt128,64}(1.2345e6))
-    @test_broken String(take!(iob)) == "Normed{UInt128,64}(1.2345e6)" # "N64f64" is not defined
+    @test String(take!(iob)) == "Normed{UInt128,64}(1.2345e6)"
 end
 
 @testset "summary" begin
@@ -487,13 +487,13 @@ end
     aa = Normed[0.2N0f8 0.4N0f16]
 
     if VERSION >= v"1.6.0-DEV.356"
-        @test_broken summary(a) == "2-element Vector{N0f8}"
-        @test_broken summary(view(a, 1:2)) == "2-element view(::Vector{N0f8}, 1:2) with eltype N0f8"
-        @test_broken summary(aa) == "1×2 Matrix{Normed}"
+        @test summary(a) == "2-element Vector{N0f8}"
+        @test summary(view(a, 1:2)) == "2-element view(::Vector{N0f8}, 1:2) with eltype N0f8"
+        @test summary(aa) == "1×2 Matrix{Normed}"
     else
         @test summary(a) == "2-element Array{N0f8,1} with eltype Normed{UInt8,8}"
         @test summary(view(a, 1:2)) == "2-element view(::Array{N0f8,1}, 1:2) with eltype Normed{UInt8,8}"
-        @test_broken summary(aa) == "1×2 Array{Normed,2}"
+        @test summary(aa) == "1×2 Array{Normed,2}"
     end
 end
 


### PR DESCRIPTION
Fixes #188

Before (Julia v1.4.2)
```julia
julia> N8f24[1/3 0.2]
1×2 Array{N8f24,2} with eltype Normed{UInt32,24}:
 0.333333  0.2

julia> N8f24[1/3, 0.2]
2-element Array{N8f24,1} with eltype Normed{UInt32,24}:
 0.33333333N8f24
 0.2N8f24

julia> FixedPoint[N0f8(1/3) N0f16(1/3)]
1×2 Array{Error showing value of type Array{FixedPoint,2}:
ERROR: MethodError: no method matching typechar(::Type{FixedPoint})

julia> FixedPoint[N0f8(1/3), N0f16(1/3)]
2-element Array{Error showing value of type Array{FixedPoint,1}:
ERROR: MethodError: no method matching typechar(::Type{FixedPoint})

julia> Normed{UInt128,28}(1)
1.0N100f28
```

After (Julia v1.4.2)
```julia
julia> N8f24[1/3 0.2]
1×2 Array{N8f24,2} with eltype Normed{UInt32,24}:
 0.333333  0.2

julia> N8f24[1/3, 0.2]
2-element Array{N8f24,1} with eltype Normed{UInt32,24}:
 0.33333333
 0.2

julia> FixedPoint[N0f8(1/3) N0f16(1/3)]
1×2 Array{FixedPoint,2}:
 0.333  0.33333

julia> FixedPoint[N0f8(1/3), N0f16(1/3)]
2-element Array{FixedPoint,1}:
 0.333N0f8
 0.33333N0f16

julia> Normed{UInt128,28}(1)
Normed{UInt128,28}(1.0)
```
