### PR TITLE
Add checked, wrapping and saturating arithmetic for add/sub/neg

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -1,5 +1,6 @@
 using FixedPointNumbers, Statistics, Random, Test
 using FixedPointNumbers: bitwidth, rawtype, nbitsfrac
+using Base.Checked
 
 """
     target(X::Type, Ss...; ex = :default)


### PR DESCRIPTION
Closes #152.

The default arithmetic is still the wrapping arithmetic.

```julia
julia> using CheckedArithmetic

julia> @checked N0f8(0) + N0f8(1)
1.0N0f8

julia> @checked N0f8(0.5) + N0f8(0.5)
ERROR: OverflowError: 128 + 128 overflowed for type UInt8

julia> @checked 1N0f8 # Maybe some other time.
ERROR: MethodError: no method matching checked_mul(::Int64, ::Type{Normed{UInt8,8}})

julia> wrapping_add(0.5N0f8, 0.5N0f8)
0.0N0f8

julia> saturating_add(0.5N0f8, 0.5N0f8)
1.0N0f8
```
We may want to customize the overflow message.