### PR TITLE
Version 0.8.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedPointNumbers"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FixedPointNumbers
 
 [![Build Status](https://travis-ci.org/JuliaMath/FixedPointNumbers.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/FixedPointNumbers.jl)
-
+[![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/F/FixedPointNumbers.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)
 [![codecov.io](http://codecov.io/github/JuliaMath/FixedPointNumbers.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaMath/FixedPointNumbers.jl?branch=master)
 
 This library implements fixed-point number types.  A
@@ -55,10 +55,9 @@ value `1.0` at 10, 12, 14, and 16 bits, respectively (`0x03ff`,
 compact printing and the `fY` component informs about the number of
 fractional bits and `X+Y` equals the number of underlying bits used.
 
-To construct such a number, use `convert(N4f12, 1.3)`, `N4f12(1.3)`,
+To construct such a number, use `1.3N4f12`, `N4f12(1.3)`, `convert(N4f12, 1.3)`,
 `Normed{UInt16,12}(1.3)`, or `reinterpret(N4f12, 0x14cc)`.
-The latter syntax means to construct a `N4f12` (it ends in
-`uf12`) from the `UInt16` value `0x14cc`.
+The last syntax means to construct a `N4f12` from the `UInt16` value `0x14cc`.
 
 More generally, an arbitrary number of bits from any of the standard unsigned
 integer widths can be used for the fractional part.  For example:

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -3,7 +3,7 @@ module FixedPointNumbers
 import Base: ==, <, <=, -, +, *, /, ~, isapprox,
              convert, promote_rule, show, isinteger, abs, decompose,
              isnan, isinf, isfinite,
-             zero, oneunit, one, typemin, typemax, floatmin, floatmax, eps, sizeof, reinterpret,
+             zero, oneunit, one, typemin, typemax, floatmin, floatmax, eps, reinterpret,
              float, trunc, round, floor, ceil, bswap,
              div, fld, rem, mod, mod1, fld1, min, max, minmax,
              rand, length


### PR DESCRIPTION
PR #177 is a relatively important change, so I'll release v0.8.2 here.

I'm planning to release v0.8.3 after newly adding support for `clamp` and `bitstring` (cf. Issue #185), which are not related to improvements in arithmetic. (**Edit:** cf. PR #194, PR #195)

This also updates README.md and adds the PkgEval badge. `uf12` is the remnant of the obsolete syntax `0x14ccuf12`.