### PR TITLE
disable comment from codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Sometimes comment from codecov is annoying, and it can be disabled.

I'm not sure if this is wanted, just open it in case if you're not aware that this is doable.

Just merge or close it at will.