### PR TITLE
Fix overflow in Float --> `Normed{T,f}` conversions where `f == 1`

### DIFF
--- a/src/normed.jl
+++ b/src/normed.jl
@@ -76,6 +76,7 @@ function _convert(::Type{N}, x::Tf) where {T, f, N <: Normed{T,f}, Tf <: Union{F
         0 <= x <= Tf((typemax(T)-rawone(N))/rawone(N)+1) || throw_converterror(N, x)
     end
 
+    f == 1 && x == Tf(typemax(N)) && return typemax(N)
     if f <= (significand_bits(Tf) + 1) && bitwidth(T) < significand_bits(Tf)
         return reinterpret(N, unsafe_trunc(T, round(rawone(N) * x)))
     end

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -158,7 +158,8 @@ end
                 if isinf(input_typemax)
                     @test reinterpret(N(floatmax(Tf))) >= round(T, floatmax(Tf))
                 else
-                    @test reinterpret(N(input_typemax)) >= (typemax(T)>>1) # overflow check
+                    @test reinterpret(N(input_typemax)) > (typemax(T)>>1) # overflow check
+                    @test N(input_typemax) >= N(prevfloat(input_typemax))
                 end
 
                 input_upper = Tf(BigFloat(typemax(T)) / r, RoundDown)


### PR DESCRIPTION
Fixes #200.

~This fix definitely works on Intel CPUs, but ARM seems to have some other trouble.~
The problem on ARM CPUs seems to be related to `BigFloat` instead of `Float32`/`Float64` (cf. #202). Therefore, there seems to be no problem regarding conversion from `Float32`/`Float64`.