### PR TITLE
Fix `_unsafe_trunc` for `BigFloat` on ARM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedPointNumbers"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -54,7 +54,7 @@ end
 
 function _convert(::Type{F}, x::Integer) where {T, f, F <: Fixed{T,f}}
     if ((typemin(T) >> f) <= x) & (x <= (typemax(T) >> f))
-        reinterpret(F, unsafe_trunc(T, x) << f)
+        reinterpret(F, _unsafe_trunc(T, x) << f)
     else
         throw_converterror(F, x)
     end

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -323,12 +323,3 @@ end
     end
     :(Normed{$T,$f})
 end
-
-_unsafe_trunc(::Type{T}, x::Integer) where {T} = x % T
-_unsafe_trunc(::Type{T}, x) where {T}          = unsafe_trunc(T, x)
-if !signbit(signed(unsafe_trunc(UInt, -12.345)))
-    # a workaround for 32-bit ARMv7 (issue #134)
-    function _unsafe_trunc(::Type{T}, x::AbstractFloat) where {T}
-        unsafe_trunc(T, unsafe_trunc(typeof(signed(zero(T))), x))
-    end
-end


### PR DESCRIPTION
Fixes #202.

This also moves `_unsafe_trunc` to "src/utilities.jl". It has been used in ”fixed.jl" for 2 years.
https://github.com/JuliaMath/FixedPointNumbers.jl/blob/39d46876dc641acf60c24fa4bb6f16575f3121d7/src/fixed.jl#L53

----

I didn't have the plans, but I'd like to release v0.8.4.

