### PR TITLE
Improve `throw_converterror`

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -296,7 +296,7 @@ function show(io::IO, x::FixedPoint{T,f}) where {T,f}
     end
 end
 
-if VERSION < v"1.6.0-DEV.356"
+if VERSION < v"1.6.0-DEV.356" # JuliaLang/julia#36107
     function Base.showarg(io::IO, a::Array{X}, toplevel) where {X<:FixedPoint}
         toplevel || print(io, "::")
         print(io, "Array{")
@@ -340,13 +340,17 @@ scaledual(::Type{Tdual}, x::FixedPoint) where Tdual = convert(Tdual, 1/rawone(x)
 scaledual(::Type{Tdual}, x::AbstractArray{T}) where {Tdual, T <: FixedPoint} =
     convert(Tdual, 1/rawone(T)), reinterpret(rawtype(T), x)
 
-@noinline function throw_converterror(::Type{X}, x) where {X <: FixedPoint}
-    n = 2^bitwidth(X)
-    bitstring = bitwidth(X) == 8 ? "an 8-bit" : "a $(bitwidth(X))-bit"
+@noinline function throw_converterror(::Type{X}, @nospecialize(x)) where X <: FixedPoint
+    nbits = bitwidth(rawtype(X))
     io = IOBuffer()
-    show(IOContext(io, :compact=>true), typemin(X)); Xmin = String(take!(io))
-    show(IOContext(io, :compact=>true), typemax(X)); Xmax = String(take!(io))
-    throw(ArgumentError("$X is $bitstring type representing $n values from $Xmin to $Xmax; cannot represent $x"))
+    showtype(io, X)
+    print(io, " is ")
+    print(io, nbits == 8 ? "an " : "a ", nbits, "-bit type representing ")
+    print(io, nbits <= 16 ? string(2^nbits) : "2^$nbits", " values from ")
+    print(IOContext(io, :compact=>true), typemin(X), " to ")
+    print(IOContext(io, :compact=>true), typemax(X), "; ")
+    print(io, "cannot represent ", x)
+    throw(ArgumentError(String(take!(io))))
 end
 
 rand(::Type{T}) where {T <: FixedPoint} = reinterpret(T, rand(rawtype(T)))

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -90,20 +90,25 @@ end
     @test_throws ArgumentError one(Q0f15)
     @test_throws ArgumentError oneunit(Q0f31)
     @test_throws ArgumentError one(Fixed{Int8,8}) # TODO: remove this at end of its support
+
+    @test_throws ArgumentError convert(Q0f7, 0.999)
+    @test_throws ArgumentError convert(Q0f7, 1.0)
+    @test_throws ArgumentError convert(Q0f7, 1)
+    @test_throws ArgumentError convert(Q0f7, 2)
+
+    ret = @test_throws ArgumentError Q0f7(127)
+    msg = ret.value.msg
+    @test occursin("Q0f7 is an 8-bit type representing 256 values from -1.0 to 0.992;", msg)
+    ret = @test_throws ArgumentError convert(Fixed{Int128,100}, 10.0^9)
+    msg = ret.value.msg
+    @test occursin("Fixed{Int128,100} is a 128-bit type representing 2^128 values", msg)
 end
 
 @testset "conversion" begin
     @test isapprox(convert(Fixed{Int8,7}, 0.8), 0.797, atol=0.001)
     @test isapprox(convert(Fixed{Int8,7}, 0.9), 0.898, atol=0.001)
-    @test_throws ArgumentError convert(Fixed{Int8, 7}, 0.999)
-    @test_throws ArgumentError convert(Fixed{Int8, 7}, 1.0)
-    @test_throws ArgumentError convert(Fixed{Int8, 7}, 1)
-    @test_throws ArgumentError convert(Fixed{Int8, 7}, 2)
-    @test_throws ArgumentError convert(Fixed{Int8, 7}, 128)
-    @test_throws ArgumentError convert(Fixed{Int8, 7}, 1.0)
 
     @test convert(Q0f7, -128.5/128) == -1
-
     @test convert(Q0f7, -0.75f0) == -0.75
     @test convert(Q0f7, Float16(-0.75)) == -0.75
     @test convert(Q0f7, BigFloat(-0.75)) == -0.75

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -69,7 +69,6 @@ end
 @testset "inexactness" begin
     # TODO: change back to InexactError when it allows message strings
     @test_throws ArgumentError N0f8(2)
-    @test_throws ArgumentError N0f8(255)
     @test_throws ArgumentError N0f8(0xff)
     @test_throws ArgumentError N0f16(2)
     @test_throws ArgumentError N0f16(0xff)
@@ -77,7 +76,13 @@ end
     @test_throws ArgumentError convert(N0f8,  typemax(N6f10))
     @test_throws ArgumentError convert(N0f16, typemax(N6f10))
     @test_throws ArgumentError convert(Normed{UInt128,100}, 10^9)
-    @test_throws ArgumentError convert(Normed{UInt128,100}, 10.0^9)
+
+    ret = @test_throws ArgumentError N0f8(255)
+    msg = ret.value.msg
+    @test occursin("N0f8 is an 8-bit type representing 256 values from 0.0 to 1.0;", msg)
+    ret = @test_throws ArgumentError convert(Normed{UInt128,100}, 10.0^9)
+    msg = ret.value.msg
+    @test occursin("Normed{UInt128,100} is a 128-bit type representing 2^128 values", msg)
 end
 
 @testset "conversion" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaMath/FixedPointNumbers.jl/issues/188#issuecomment-662333257

This uses the type aliases for the message and avoids showing huge numbers.
This also reduces the compilation time, i.e. the CI time.

Although the time for testing on the CI is unsettled, this saves about 10 seconds on my local Windows machine. FYI, I could not feel the time saving effect of the `@nospecialize(X)` for the first argument.