### PR TITLE
Use sampler-based Random API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
 
 [deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Statistics, Test
+using FixedPointNumbers, Statistics, Random, Test
 using FixedPointNumbers: bitwidth, rawtype, nbitsfrac
 
 """

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -436,6 +436,7 @@ end
         @test ndims(a) == 2 && eltype(a) === F
         @test size(a) == (3,5)
     end
+    @test rand(MersenneTwister(1234), Q0f7) === -0.156Q0f7
 end
 
 @testset "Promotion within Fixed" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -466,6 +466,7 @@ end
         @test ndims(a) == 2 && eltype(a) === N
         @test size(a) == (3,5)
     end
+    @test rand(MersenneTwister(1234), N0f8) === 0.925N0f8
 end
 
 @testset "Promotion within Normed" begin


### PR DESCRIPTION
Closes #196, Fixes #125

This avoids the performance problem with `ReinterpretArray`. ~On the other hand, the time for generating the random number array with the default RNG is significantly increased.~

~I chose a minimalistic and straightforward implementation for now.~