### PR TITLE
Avoid inconsistent behavior of `unsafe_trunc` for `BigFloat`

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -38,14 +38,15 @@ exponent_bias(::Type{Float32}) = 127
 exponent_bias(::Type{Float64}) = 1023
 
 _unsafe_trunc(::Type{T}, x::Integer) where {T} = x % T
-_unsafe_trunc(::Type{T}, x) where {T}          = unsafe_trunc(T, x)
+_unsafe_trunc(::Type{T}, x) where {T} = unsafe_trunc(T, x)
+# issue #202, #211
+_unsafe_trunc(::Type{T}, x::BigFloat) where {T <: Integer} = trunc(BigInt, x) % T
+
 if !signbit(signed(unsafe_trunc(UInt, -12.345)))
     # a workaround for ARM (issue #134)
     function _unsafe_trunc(::Type{T}, x::AbstractFloat) where {T <: Integer}
         unsafe_trunc(T, unsafe_trunc(signedtype(T), x))
     end
-    # exclude BigFloat (issue #202)
-    _unsafe_trunc(::Type{T}, x::BigFloat) where {T <: Integer} = unsafe_trunc(T, x)
 end
 
 wrapper(@nospecialize(T)) = Base.typename(T).wrapper

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -263,6 +263,10 @@ end
     # issue #150
     @test all(f -> 1.0f0 % Normed{UInt32,f} == oneunit(Normed{UInt32,f}), 1:32)
     @test all(f -> 1.0e0 % Normed{UInt64,f} == oneunit(Normed{UInt64,f}), 1:64)
+
+    # issu #211
+    @test big"1.2" % N0f8 === 0.196N0f8
+    @test reinterpret(BigFloat(0x0_01234567_89abcdef) % N63f1) === 0x01234567_89abcdef
 end
 
 @testset "arithmetic" begin


### PR DESCRIPTION
Fixes #211