### PR TITLE
Optimize multiplication for Normed

### DIFF
--- a/test/normed.jl
+++ b/test/normed.jl
@@ -394,6 +394,33 @@ end
     end
 end
 
+@testset "mul" begin
+    for N in target(Normed; ex = :thin)
+        @test   wrapping_mul(typemax(N), zero(N)) === zero(N)
+        @test saturating_mul(typemax(N), zero(N)) === zero(N)
+        @test    checked_mul(typemax(N), zero(N)) === zero(N)
+
+        @test   wrapping_mul(one(N), typemax(N)) === typemax(N)
+        @test saturating_mul(one(N), typemax(N)) === typemax(N)
+        @test    checked_mul(one(N), typemax(N)) === typemax(N)
+
+        @test   wrapping_mul(typemax(N), typemax(N)) === big(typemax(N))^2 % N
+        @test saturating_mul(typemax(N), typemax(N)) === typemax(N)
+        if typemax(N) != 1
+            @test_throws OverflowError checked_mul(typemax(N), typemax(N))
+        end
+    end
+    for N in target(Normed, :i8; ex = :thin)
+        xs = typemin(N):eps(N):typemax(N)
+        xys = ((x, y) for x in xs, y in xs)
+        fmul(x, y) = float(x) * float(y) # note that precision(Float32) < 32
+        @test all(((x, y),) -> wrapping_mul(x, y) === fmul(x, y) % N, xys)
+        @test all(((x, y),) -> saturating_mul(x, y) === clamp(fmul(x, y), N), xys)
+        @test all(((x, y),) -> !(typemin(N) <= fmul(x, y) <= typemax(N)) ||
+                               wrapping_mul(x, y) === checked_mul(x, y), xys)
+    end
+end
+
 @testset "div/fld1" begin
     @test div(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == fld(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == 8
     @test div(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == fld(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == 7


### PR DESCRIPTION
This adds `wrapping_mul`, `saturating_mul` and `checked_mul` binary operations. However, this does not specialize them for `Fixed` and does not change [`*` for `Fixed`](https://github.com/JuliaMath/FixedPointNumbers.jl/blob/5dcaf979ac148012d7d95b018232c9a86d7416a9/src/fixed.jl#L103).

This applies the wrapping arithmetic as the default arithmetic of `*` for the abstract `FixedPoint`, but as mentioned above, the `*`for `Fixed` is not affected by the default arithmetic. Furthermore, `*` for `Normed` overrides the default arithmetic with the "checked" arithmetic for backward compatibility. (Strictly speaking, the error type is changed from `ArgumentError` to `OverflowError`.)

This replaces most of Normed's implementation of multiplication with integer operations. This improves the speed in many cases and the accuracy in some cases.

Fixes #174