### PR TITLE
Improve overflow error message

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -275,8 +275,8 @@ end
         xs = typemin(F):eps(F):typemax(F)
         fneg(x) = -float(x)
         @test all(x -> wrapping_neg(wrapping_neg(x)) === x, xs)
-        @test all(x -> saturating_neg(x) == clamp(fneg(x), F), xs)
-        @test all(x -> !(typemin(F) < fneg(x) < typemax(F)) ||
+        @test all(x -> saturating_neg(x) === clamp(fneg(x), F), xs)
+        @test all(x -> !(typemin(F) <= fneg(x) <= typemax(F)) ||
                        wrapping_neg(x) === checked_neg(x) === fneg(x) % F, xs)
     end
 end
@@ -301,8 +301,8 @@ end
         xys = ((x, y) for x in xs, y in xs)
         fadd(x, y) = float(x) + float(y)
         @test all(((x, y),) -> wrapping_sub(wrapping_add(x, y), y) === x, xys)
-        @test all(((x, y),) -> saturating_add(x, y) == clamp(fadd(x, y), F), xys)
-        @test all(((x, y),) -> !(typemin(F) < fadd(x, y) < typemax(F)) ||
+        @test all(((x, y),) -> saturating_add(x, y) === clamp(fadd(x, y), F), xys)
+        @test all(((x, y),) -> !(typemin(F) <= fadd(x, y) <= typemax(F)) ||
                                wrapping_add(x, y) === checked_add(x, y) === fadd(x, y) % F, xys)
     end
 end

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -303,7 +303,7 @@ end
         fneg(x) = -float(x)
         @test all(x -> wrapping_neg(wrapping_neg(x)) === x, xs)
         @test all(x -> saturating_neg(x) === clamp(fneg(x), N), xs)
-        @test all(x -> !(typemin(N) < fneg(x) < typemax(N)) ||
+        @test all(x -> !(typemin(N) <= fneg(x) <= typemax(N)) ||
                        wrapping_neg(x) === checked_neg(x) === fneg(x) % N, xs)
     end
 end
@@ -329,7 +329,7 @@ end
         fadd(x, y) = float(x) + float(y)
         @test all(((x, y),) -> wrapping_sub(wrapping_add(x, y), y) === x, xys)
         @test all(((x, y),) -> saturating_add(x, y) === clamp(fadd(x, y), N), xys)
-        @test all(((x, y),) -> !(typemin(N) < fadd(x, y) < typemax(N)) ||
+        @test all(((x, y),) -> !(typemin(N) <= fadd(x, y) <= typemax(N)) ||
                                wrapping_add(x, y) === checked_add(x, y) === fadd(x, y) % N, xys)
     end
 end
@@ -354,7 +354,7 @@ end
         fsub(x, y) = float(x) - float(y)
         @test all(((x, y),) -> wrapping_add(wrapping_sub(x, y), y) === x, xys)
         @test all(((x, y),) -> saturating_sub(x, y) === clamp(fsub(x, y), N), xys)
-        @test all(((x, y),) -> !(typemin(N) < fsub(x, y) < typemax(N)) ||
+        @test all(((x, y),) -> !(typemin(N) <= fsub(x, y) <= typemax(N)) ||
                                wrapping_sub(x, y) === checked_sub(x, y) === fsub(x, y) % N, xys)
     end
 end


### PR DESCRIPTION
This displays the fixed point type of the input in the message, not the rawtype. (cf. https://github.com/JuliaMath/FixedPointNumbers.jl/pull/190#issue-445137281)
```julia
julia> checked_add(0.5N0f8, 0.5N0f8) # this PR
ERROR: OverflowError: 0.502N0f8 + 0.502N0f8 overflowed for type N0f8
```
Of course, more information could be added to the error message, but I think the error message in the constructor is sufficient to supplement it.
```julia
julia> 1.004N0f8
ERROR: ArgumentError: N0f8 is an 8-bit type representing 256 values from 0.0 to 1.0; cannot represent 1.004
```

This also avoids the stall with `checked_{add/sub}` on Windows. (cf. https://github.com/JuliaMath/FixedPointNumbers.jl/pull/190#issuecomment-674334221) TBH, this is the real purpose of this PR. :sweat_smile:
```julia
julia> @btime checked_add.($x, $y);
  898.900 μs (2 allocations: 976.70 KiB) # before (on Windows)
  577.699 μs (2 allocations: 976.70 KiB) # after (on Windows)
  678.800 μs (2 allocations: 976.70 KiB) # before (on Linux)
  679.500 μs (2 allocations: 976.70 KiB) # after (on Linux)
```