### PR TITLE
Improve `isapprox`

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -406,6 +406,15 @@ end
         @test all(x -> x + eps(F) ≈ x, xs)
         @test !any(x -> x - eps(F) ≈ x + eps(F), xs)
     end
+
+    @test isapprox(-0.5Q0f7, -1Q0f7, rtol=0.5, atol=0) # issue 209
+    @test isapprox(typemin(Q0f7), typemax(Q0f7), rtol=2.0)
+    @test !isapprox(zero(Q0f7), typemax(Q0f7), rtol=0.9)
+    @test isapprox(zero(Q0f7), eps(Q0f7), rtol=1e-6) # atol = eps(Q0f7)
+    @test !isapprox(eps(Q0f7), zero(Q0f7), rtol=1e-6, atol=1e-6)
+    @test !isapprox(1.0Q6f1, 1.5Q6f1, rtol=0.3, atol=0) # 1.5 * 0.3 < eps(Q6f1)
+
+    @test isapprox(eps(Q8f7), eps(Q0f7), rtol=1e-6)
 end
 
 @testset "clamp" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -431,6 +431,14 @@ end
         @test all(x -> x + eps(N) ≈ x, xs)
         @test !any(x -> x - eps(N) ≈ x + eps(N), xs)
     end
+
+    @test isapprox(typemin(N0f8), typemax(N0f8), rtol=1.0)
+    @test !isapprox(zero(N0f8), typemax(N0f8), rtol=0.9)
+    @test isapprox(zero(N0f8), eps(N0f8), rtol=1e-6) # atol = eps(N0f8)
+    @test !isapprox(eps(N0f8), zero(N0f8), rtol=1e-6, atol=1e-6)
+    @test !isapprox(0.66N6f2, 1.0N6f2, rtol=0.3, atol=0) # 1.0 * 0.3 < eps(N6f2)
+
+    @test isapprox(eps(N8f8), eps(N0f8), rtol=1e-6)
 end
 
 @testset "comparison" begin


### PR DESCRIPTION
This changes the association between absolute tolerance and relative tolerance from additive (`+`) to `max` to match the behavior in `Base` of Julia v1 (cf. https://github.com/JuliaMath/FixedPointNumbers.jl/issues/209#issuecomment-671012997). 

This also fixes an overflow problem and a rounding problem.
```julia
julia> isapprox(-0.5Q0f7, -1Q0f7, rtol=0.5, atol=0)
false # before
true  # after

julia> isapprox(1.0Q6f1, 1.5Q6f1, rtol=0.3, atol=0) # 1.5 * 0.3 < eps(Q6f1)
true  # before
false # after

julia> isapprox(0N0f8, 1N0f8, atol=1.1)
ERROR: ArgumentError: Normed{UInt8,8} is an 8-bit type representing 256 values from 0.0 to 1.0; cannot represent 1.1 # before
true # after
```

The use of `isapprox` in a "strict" manner is rare, and I think the impact of these breaking changes are actually minor. However, these changes are difficult to notice and can affect the test results, so I labeled this PR with the "breaking" label as a marker.

This also speeds up the operation with default tolerance settings.

Fixes #209