### PR TITLE
Change test targets of `Fixed`

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -105,7 +105,7 @@ T == UInt32 |x - - - - - - -:- - - - - - - -:x - - - - - - -:- - - - - - - -|
 """
 function target_f(X::Type, T::Type{<:Integer}; ex = :default)
     f_min = X === Fixed ? 0 : 1
-    f_max = bitwidth(T) - (T <: Signed) - 1 + f_min
+    f_max = bitwidth(T) - (T <: Signed)
     ex === :heavy && return f_min:f_max
     ex === :default && bitwidth(T) <= 16 && return f_min:f_max
     ex === :thin && return ((f_max + 1) ÷ 2, f_max)


### PR DESCRIPTION
During the revision of PR #208, I unintentionally dropped the upper limit of the number of fractional bits `f` for `Fixed` (e.g. `Q0f7` --> `Q0f6`).

Of course, the tests should be passed independent of `f`, so *ideally* the selection of `f`s makes no difference. However, in general, the quality of tests is higher when using boundary values. In fact, two edge cases (but not a bug) have been detected.