### PR TITLE
Add checked arithmetic for `/`

### DIFF
--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -179,7 +179,6 @@ function mul_with_rounding(x::F, y::F, ::RoundingMode{:Down}) where
     F((widemul(x.i, y.i) >> f) % T, 0)
 end
 
-/(x::Fixed{T,f}, y::Fixed{T,f}) where {T,f} = Fixed{T,f}(div(convert(widen(T), x.i) << f, y.i), 0)
 
 function trunc(x::Fixed{T,f}) where {T, f}
     f == 0 && return x

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -291,7 +291,6 @@ end
 # Override the default arithmetic with `checked` for backward compatibility
 *(x::N, y::N) where {N <: Normed} = checked_mul(x, y)
 
-/(x::T, y::T) where {T <: Normed} = convert(T,convert(floattype(T), x)/convert(floattype(T), y))
 
 # Functions
 trunc(x::N) where {N <: Normed} = floor(x)

--- a/test/common.jl
+++ b/test/common.jl
@@ -222,6 +222,18 @@ function test_mul(TX::Type)
     end
 end
 
+function test_fdiv(TX::Type)
+    for X in target(TX, :i8; ex = :thin)
+        xys = xypairs(X)
+        fdiv(x, y) = oftype(float(x), big(x) / big(y))
+        fdivz(x, y) = y === zero(y) ? float(y) : fdiv(x, y)
+        @test all(((x, y),) -> wrapping_fdiv(x, y) === fdivz(x, y) % X, xys)
+        @test all(((x, y),) -> saturating_fdiv(x, y) === clamp(fdiv(x, y), X), xys)
+        @test all(((x, y),) -> !(typemin(X) <= fdiv(x, y) <= typemax(X)) ||
+                               wrapping_fdiv(x, y) === checked_fdiv(x, y), xys)
+    end
+end
+
 function test_isapprox(TX::Type)
     @testset "approx $X" for X in target(TX, :i8, :i16; ex = :light)
         xs = typemin(X):eps(X):typemax(X)-eps(X)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -377,6 +377,31 @@ end
     FixedPointNumbers.mul_with_rounding(1.5Q6f1, -0.5Q6f1, RoundDown) === -1.0Q6f1
 end
 
+@testset "fdiv" begin
+    for F in target(Fixed; ex = :thin)
+        @test   wrapping_fdiv(typemax(F), -typemax(F)) === F(-1)
+        @test saturating_fdiv(typemax(F), -typemax(F)) === F(-1)
+        @test    checked_fdiv(typemax(F), -typemax(F)) === F(-1)
+
+        @test   wrapping_fdiv(zero(F), typemin(F)) === zero(F)
+        @test saturating_fdiv(zero(F), typemin(F)) === zero(F)
+        @test    checked_fdiv(zero(F), typemin(F)) === zero(F)
+
+        @test   wrapping_fdiv(typemin(F), F(-1)) === wrapping_neg(typemin(F))
+        @test saturating_fdiv(typemin(F), F(-1)) === typemax(F)
+        @test_throws OverflowError checked_fdiv(typemin(F), F(-1))
+
+        @test   wrapping_fdiv(zero(F), zero(F)) === zero(F)
+        @test saturating_fdiv(zero(F), zero(F)) === zero(F)
+        @test_throws DivideError checked_fdiv(zero(F), zero(F))
+
+        @test   wrapping_fdiv(-eps(F), zero(F)) === zero(F)
+        @test saturating_fdiv(-eps(F), zero(F)) === typemin(F)
+        @test_throws DivideError checked_fdiv(-eps(F), zero(F))
+    end
+    test_fdiv(Fixed)
+end
+
 @testset "rounding" begin
     for sym in (:i8, :i16, :i32, :i64)
         T = symbol_to_inttype(Fixed, sym)

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -380,6 +380,31 @@ end
     test_mul(Normed)
 end
 
+@testset "fdiv" begin
+    for N in target(Normed; ex = :thin)
+        @test   wrapping_fdiv(typemax(N), typemax(N)) === one(N)
+        @test saturating_fdiv(typemax(N), typemax(N)) === one(N)
+        @test    checked_fdiv(typemax(N), typemax(N)) === one(N)
+
+        @test   wrapping_fdiv(zero(N), eps(N)) === zero(N)
+        @test saturating_fdiv(zero(N), eps(N)) === zero(N)
+        @test    checked_fdiv(zero(N), eps(N)) === zero(N)
+
+        @test   wrapping_fdiv(typemax(N), eps(N)) === (floattype(N))(typemax(rawtype(N))) % N
+        @test saturating_fdiv(typemax(N), eps(N)) === typemax(N)
+        @test_throws OverflowError checked_fdiv(typemax(N), eps(N))
+
+        @test   wrapping_fdiv(zero(N), zero(N)) === zero(N)
+        @test saturating_fdiv(zero(N), zero(N)) === zero(N)
+        @test_throws DivideError checked_fdiv(zero(N), zero(N))
+
+        @test   wrapping_fdiv(eps(N), zero(N)) === zero(N)
+        @test saturating_fdiv(eps(N), zero(N)) === typemax(N)
+        @test_throws DivideError checked_fdiv(eps(N), zero(N))
+    end
+    test_fdiv(Normed)
+end
+
 @testset "div/fld1" begin
     @test div(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == fld(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == 8
     @test div(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == fld(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == 7


### PR DESCRIPTION
This also changes the implementation of `/` for `Fixed`. The new `/` also checks for overflow.

`/` (`checked_fdiv`) throws `DivideError` for division by zero and `OverflowError` for overflow.
```julia
julia> 0.5Q0f7 / 0Q0f7 # v0.8.4 and this PR
ERROR: DivideError: integer division error

julia> 0.5N0f8 / 0N0f8 # v0.8.4
ERROR: ArgumentError: Normed{UInt8,8} is an 8-bit type representing 256 values from 0.0 to 1.0; cannot represent Inf

julia> 0.5N0f8 / 0N0f8 # this PR
ERROR: DivideError: integer division error
```
```julia
julia> -1Q0f7 / -1Q0f7 # v0.8.4
-1.0Q0f7

julia> -1Q0f7 / -1Q0f7 # this PR
ERROR: OverflowError: -1.0Q0f7 / -1.0Q0f7 overflowed for type Q0f7

julia> 1N0f8 / 0.5N0f8 # v0.8.4
ERROR: ArgumentError: Normed{UInt8,8} is an 8-bit type representing 256 values from 0.0 to 1.0; cannot represent 1.9921874

julia> 1N0f8 / 0.5N0f8 # this PR
ERROR: OverflowError: 1.0N0f8 / 0.502N0f8 overflowed for type N0f8
```