### PR TITLE
Add checked, wrapping and saturating arithmetic for div/cld/fld

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -402,6 +402,56 @@ end
     test_fdiv(Fixed)
 end
 
+@testset "div/cld/fld" begin
+    for F in target(Fixed; ex = :thin)
+        fm, fn, fz, fe = typemax(F), typemin(F), zero(F), eps(F)
+        T = rawtype(F)
+        @test   wrapping_div(fm, fm) ===   wrapping_fld(fm, fm) ===   wrapping_cld(fm, fm) === one(T)
+        @test saturating_div(fm, fm) === saturating_fld(fm, fm) === saturating_cld(fm, fm) === one(T)
+        @test    checked_div(fm, fm) ===    checked_fld(fm, fm) ===    checked_cld(fm, fm) === one(T)
+
+        @test   wrapping_div(fz, fe) ===   wrapping_fld(fz, fe) ===   wrapping_cld(fz, fe) === zero(T)
+        @test saturating_div(fz, fe) === saturating_fld(fz, fe) === saturating_cld(fz, fe) === zero(T)
+        @test    checked_div(fz, fe) ===    checked_fld(fz, fe) ===    checked_cld(fz, fe) === zero(T)
+
+        @test   wrapping_div(fm, fe) ===   wrapping_fld(fm, fe) ===   wrapping_cld(fm, fe) === typemax(T)
+        @test saturating_div(fm, fe) === saturating_fld(fm, fe) === saturating_cld(fm, fe) === typemax(T)
+        @test    checked_div(fm, fe) ===    checked_fld(fm, fe) ===    checked_cld(fm, fe) === typemax(T)
+
+        @test   wrapping_div(fz, fz) ===   wrapping_fld(fz, fz) ===   wrapping_cld(fz, fz) === zero(T)
+        @test saturating_div(fz, fz) === saturating_fld(fz, fz) === saturating_cld(fz, fz) === zero(T)
+        @test_throws DivideError checked_div(fz, fz)
+        @test_throws DivideError checked_fld(fz, fz)
+        @test_throws DivideError checked_cld(fz, fz)
+
+        @test   wrapping_div(fe, fz) ===   wrapping_fld(fe, fz) ===   wrapping_cld(fe, fz) === zero(T)
+        @test saturating_div(fe, fz) === saturating_fld(fe, fz) === saturating_cld(fe, fz) === typemax(T)
+        @test_throws DivideError checked_div(fe, fz)
+        @test_throws DivideError checked_fld(fe, fz)
+        @test_throws DivideError checked_cld(fe, fz)
+
+        @test   wrapping_div(fn, -fe) ===   wrapping_fld(fn, -fe) ===   wrapping_cld(fn, -fe) === typemin(T)
+        @test saturating_div(fn, -fe) === saturating_fld(fn, -fe) === saturating_cld(fn, -fe) === typemax(T)
+        @test_throws OverflowError checked_div(fn, -fe)
+        @test_throws OverflowError checked_fld(fn, -fe)
+        @test_throws OverflowError checked_cld(fn, -fe)
+
+        @test wrapping_div(fe, fm) === saturating_div(fe, fm) === checked_div(fe, fm) === zero(T)
+        @test wrapping_fld(fe, fm) === saturating_fld(fe, fm) === checked_fld(fe, fm) === zero(T)
+        @test wrapping_cld(fe, fm) === saturating_cld(fe, fm) === checked_cld(fe, fm) === one(T)
+
+        @test wrapping_div(fe, fn) === saturating_div(fe, fn) === checked_div(fe, fn) === zero(T)
+        @test wrapping_fld(fe, fn) === saturating_fld(fe, fn) === checked_fld(fe, fn) === -one(T)
+        @test wrapping_cld(fe, fn) === saturating_cld(fe, fn) === checked_cld(fe, fn) === zero(T)
+    end
+    test_div(Fixed)
+    test_div_3arg(Fixed)
+end
+
+@testset "fld1/mod1" begin
+    test_fld1_mod1(Fixed)
+end
+
 @testset "rounding" begin
     for sym in (:i8, :i16, :i32, :i64)
         T = symbol_to_inttype(Fixed, sym)

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -405,18 +405,49 @@ end
     test_fdiv(Normed)
 end
 
-@testset "div/fld1" begin
-    @test div(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == fld(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == 8
-    @test div(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == fld(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == 7
-    @test fld1(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == 8
-    @test fld1(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == 8
+@testset "div/cld/fld" begin
+    for N in target(Normed; ex = :thin)
+        nm, nz, ne = typemax(N), zero(N), eps(N)
+        T = rawtype(N)
+        @test   wrapping_div(nm, nm) ===   wrapping_fld(nm, nm) ===   wrapping_cld(nm, nm) === one(T)
+        @test saturating_div(nm, nm) === saturating_fld(nm, nm) === saturating_cld(nm, nm) === one(T)
+        @test    checked_div(nm, nm) ===    checked_fld(nm, nm) ===    checked_cld(nm, nm) === one(T)
+
+        @test   wrapping_div(nz, ne) ===   wrapping_fld(nz, ne) ===   wrapping_cld(nz, ne) === zero(T)
+        @test saturating_div(nz, ne) === saturating_fld(nz, ne) === saturating_cld(nz, ne) === zero(T)
+        @test    checked_div(nz, ne) ===    checked_fld(nz, ne) ===    checked_cld(nz, ne) === zero(T)
+
+        @test   wrapping_div(nm, ne) ===   wrapping_fld(nm, ne) ===   wrapping_cld(nm, ne) === typemax(T)
+        @test saturating_div(nm, ne) === saturating_fld(nm, ne) === saturating_cld(nm, ne) === typemax(T)
+        @test    checked_div(nm, ne) ===    checked_fld(nm, ne) ===    checked_cld(nm, ne) === typemax(T)
+
+        @test   wrapping_div(nz, nz) ===   wrapping_fld(nz, nz) ===   wrapping_cld(nz, nz) === zero(T)
+        @test saturating_div(nz, nz) === saturating_fld(nz, nz) === saturating_cld(nz, nz) === zero(T)
+        @test_throws DivideError checked_div(nz, nz)
+        @test_throws DivideError checked_fld(nz, nz)
+        @test_throws DivideError checked_cld(nz, nz)
+
+        @test   wrapping_div(ne, nz) ===   wrapping_fld(ne, nz) ===   wrapping_cld(ne, nz) === zero(T)
+        @test saturating_div(ne, nz) === saturating_fld(ne, nz) === saturating_cld(ne, nz) === typemax(T)
+        @test_throws DivideError checked_div(ne, nz)
+        @test_throws DivideError checked_fld(ne, nz)
+        @test_throws DivideError checked_cld(ne, nz)
+
+        @test wrapping_div(ne, nm) === saturating_div(ne, nm) === checked_div(ne, nm) === zero(T)
+        @test wrapping_fld(ne, nm) === saturating_fld(ne, nm) === checked_fld(ne, nm) === zero(T)
+        @test wrapping_cld(ne, nm) === saturating_cld(ne, nm) === checked_cld(ne, nm) === one(T)
+    end
+    test_div(Normed)
+    test_div_3arg(Normed)
 end
 
 @testset "rem/mod" begin
     @test mod(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == rem(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == 0
     @test mod(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == rem(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == reinterpret(N0f8, 0x01)
-    @test mod1(reinterpret(N0f8, 0x10), reinterpret(N0f8, 0x02)) == reinterpret(N0f8, 0x02)
-    @test mod1(reinterpret(N0f8, 0x0f), reinterpret(N0f8, 0x02)) == reinterpret(N0f8, 0x01)
+end
+
+@testset "fld1/mod1" begin
+    test_fld1_mod1(Normed)
 end
 
 @testset "rounding" begin


### PR DESCRIPTION
The default arithmetic for `div` is still checked arithmetic.
This changes the error type for overflow from `DivideError` to `OverflowError`.
```julia
julia> div(-1Q0f7, -eps(Q0f7))
ERROR: DivideError: integer division error # v0.8.4
ERROR: OverflowError: div(-1.0Q0f7, -0.008Q0f7) overflowed for type Int8 # this PR
```
This also adds the support for `cld` and 3-arg `div`.