### PR TITLE
Remove old iterator methods

### DIFF
--- a/src/normed.jl
+++ b/src/normed.jl
@@ -324,16 +324,6 @@ function round(::Type{Ti}, x::Normed) where {Ti <: Integer}
     convert(Ti, r > (rawone(x) >> 0x1) ? d + oneunit(rawtype(x)) : d)
 end
 
-# Iteration
-# The main subtlety here is that iterating over N0f8(0):N0f8(1) will wrap around
-# unless we iterate using a wider type
-@inline start(r::StepRange{T}) where {T <: Normed} = widen1(reinterpret(r.start))
-@inline next(r::StepRange{T}, i::Integer) where {T <: Normed} = (T(i,0), i+reinterpret(r.step))
-@inline function done(r::StepRange{T}, i::Integer) where {T <: Normed}
-    i1, i2 = reinterpret(r.start), reinterpret(r.stop)
-    isempty(r) | (i < min(i1, i2)) | (i > max(i1, i2))
-end
-
 function decompose(x::Normed)
     g = gcd(reinterpret(x), rawone(x))
     div(reinterpret(x),g), 0, div(rawone(x),g)


### PR DESCRIPTION
This removes `start`, `next` and `done`.
They are no longer used in Julia v1 and were left as private methods of `FixedPointNumbers`.

Fixes #215