### PR TITLE
dont specialize on type in showarg

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -438,7 +438,7 @@ hasalias(::Type{X}) where {T<:NotBiggerThanInt64, f, X<:FixedPoint{T,f}} = f isa
 
 # Printing. These are used to generate type-symbols, so we need them
 # before we include "src/fixed.jl" / "src/normed.jl".
-@inline function showtype(io::IO, ::Type{X}) where {X <: FixedPoint}
+@inline function showtype(io::IO, @nospecialize(X))
     if hasalias(X)
         f = nbitsfrac(X)
         m = nbitsint(X)


### PR DESCRIPTION
A significant amount of time when precompiling the package is from compiling methods like:

```
...
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 53}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 54}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 55}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 56}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 57}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 58}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 59}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 60}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 61}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 62}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 63}}})
precompile(Tuple{typeof(FixedPointNumbers.showtype), Base.GenericIOBuffer{Array{UInt8, 1}}, Type{FixedPointNumbers.Normed{UInt64, 64}}})
...
```

in

https://github.com/JuliaMath/FixedPointNumbers.jl/blob/f57e96b43ba575a05d08f62cb216ba633daf1ab8/src/fixed.jl#L32-L41

By avoiding specializing `showtype` on the type, the time for precompilation gets cut in about half.

Before:

```
1.999983 seconds (732.52 k allocations: 42.130 MiB, 0.25% gc time)
``` 

After:

```
0.899459 seconds (729.63 k allocations: 41.771 MiB, 0.70% gc time)
```

Another option could be to run that piece of code in a separate module and have that module run without inference.