### PR TITLE
Improve generation of typealiases

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -466,17 +466,18 @@ function alias_symbol(@nospecialize(X))
     Symbol(type_prefix(X), nbitsint(X), 'f', nbitsfrac(X))
 end
 
+function _alias_symbol(::Type{X}) where {X <: FixedPoint}
+    if @generated
+        sym = string(alias_symbol(X))
+        return :(Symbol($sym))
+    else
+        return alias_symbol(X)
+    end
+end
+
 @inline function showtype(io::IO, ::Type{X}) where {X <: FixedPoint}
     if hasalias(X)
-        # low-level code equivalent to `write(io, alias_symbol(X))`
-        # This is faster than dynamic string `print`ing, but still slow.
-        f = nbitsfrac(X)
-        m = nbitsint(X)
-        write(io, type_prefix(X))
-        m > 9 && write(io, (m ÷ 10) % UInt8 + 0x30)
-        write(io, (m % 10) % UInt8 + 0x30, 0x66)
-        f > 9 && write(io, (f ÷ 10) % UInt8 + 0x30)
-        write(io, (f % 10) % UInt8 + 0x30)
+        write(io, _alias_symbol(X))
     else
         print(io, X)
     end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -7,3 +7,11 @@ function floattype(::Type{T}) where {T <: Real}
         """, :floattype)
     return T
 end
+
+function typechar(::Type{X}) where {X}
+    Base.depwarn("""
+        `typechar` was deprecated since the prefix may not be a single character in the future.
+        We recommend not using private functions, but if you need to, use `type_prefix` instead.
+        """, :typechar)
+    Char(string(type_prefix(X))[1])
+end

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -27,14 +27,14 @@ end
 # TODO: remove this
 hasalias(::Type{F}) where {F <: Union{Fixed{Int8,8},Fixed{Int16,16},Fixed{Int32,32},Fixed{Int64,64}}} = false
 
-typechar(::Type{X}) where {X <: Fixed} = 'Q'
+type_prefix(::Type{F}) where {F <: Fixed{<:Signed}} = :Q
 
 for T in (Int8, Int16, Int32, Int64)
-    io = IOBuffer()
     for f in 0:bitwidth(T)-1
-        sym = Symbol(String(take!(showtype(io, Fixed{T,f}))))
+        F = Fixed{T,f}
+        sym = alias_symbol(F)
         @eval begin
-            const $sym = Fixed{$T,$f}
+            const $sym = $F
             export $sym
         end
     end

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -19,14 +19,14 @@ struct Normed{T <: Unsigned, f} <: FixedPoint{T, f}
     end
 end
 
-typechar(::Type{X}) where {X <: Normed} = 'N'
+type_prefix(::Type{N}) where {N <: Normed{<:Unsigned}} = :N
 
 for T in (UInt8, UInt16, UInt32, UInt64)
-    io = IOBuffer()
     for f in 1:bitwidth(T)
-        sym = Symbol(String(take!(showtype(io, Normed{T,f}))))
+        N = Normed{T,f}
+        sym = alias_symbol(N)
         @eval begin
-            const $sym = Normed{$T,$f}
+            const $sym = $N
             export $sym
         end
     end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -718,6 +718,8 @@ end
 end
 
 @testset "show" begin
+    @test (@test_deprecated FixedPointNumbers.typechar(Q0f7)) === 'Q'
+
     iob = IOBuffer()
     q0f7 = reinterpret(Q0f7, signed(0xaa))
     show(iob, q0f7)

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -690,6 +690,8 @@ end
 end
 
 @testset "show" begin
+    @test (@test_deprecated FixedPointNumbers.typechar(N0f8)) === 'N'
+
     iob = IOBuffer()
     n0f8 = reinterpret(N0f8, 0xaa)
     show(iob, n0f8)


### PR DESCRIPTION
This is yet another solution for the issue which is going to be fixed by PR #232.

This also includes the preparation for #228. I don't believe `typechar` is used in other packages, but I've added depwarn because there are cases where `showtype` is used.

**Edit:** 
This PR is not intended to replace #232, but to demonstrate a different approach. However, in any case, I believe that some fixes will be required for #228.