### PR TITLE
Add support for `digits` keyword argument of `round()`

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -543,6 +543,9 @@ end
         @test round(Int, -1.5Q1f6, RoundUp) === -1
         @test round(Int, -1.5Q1f6, RoundDown) === -2
     end
+    @testset "rounding with digits" begin
+        test_round_digits(Fixed)
+    end
     @test_throws InexactError trunc(UInt, typemin(Q0f7))
     @test_throws InexactError floor(UInt, -eps(Q0f7))
 end

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -515,6 +515,9 @@ end
         @test round(Int, 1.504N1f7, RoundUp) === 2
         @test round(Int, 1.504N1f7, RoundDown) === 1
     end
+    @testset "rounding with digits" begin
+        test_round_digits(Normed)
+    end
 end
 
 @testset "approx" begin


### PR DESCRIPTION
This only supports the non-negative `digits` option. All other options throw an error.
This provides specialized implementations only for `N0f8` and `Fixed{Int8}`. The other types use fallback with floating-point operations and therefore it is slower and less accurate.

Fixes #234 