### PR TITLE
Change the default arithmetic of `*` for `Normed` to wrapping

### DIFF
--- a/src/normed.jl
+++ b/src/normed.jl
@@ -288,10 +288,6 @@ function checked_mul(x::N, y::N) where {T <: Union{UInt8,UInt16,UInt32,UInt64}, 
     N(div_2fm1(z, Val(Int(f))) % T, 0)
 end
 
-# TODO: decide the default arithmetic for `Normed` mul
-# Override the default arithmetic with `checked` for backward compatibility
-*(x::N, y::N) where {N <: Normed} = checked_mul(x, y)
-
 
 # Functions
 floor(x::N) where {N <: Normed} = reinterpret(N, x.i - x.i % rawone(N))


### PR DESCRIPTION
The implementation of multiplication for `Normed` was changed in PR #213, but its arithmetic defaulted to checked arithmetic for backward compatibility.

Although the [discussion in Discourse](https://discourse.julialang.org/t/rfc-what-should-the-arithmetic-within-the-fixedpointnumbers-be/46697) is not aimed solely at building specific consensus, but at least, there is no objection to changing the default arithmetic of multiplication for `Normed` to wrapping arithmetic (i.e. [Option 2.](https://discourse.julialang.org/t/rfc-what-should-the-arithmetic-within-the-fixedpointnumbers-be/46697/3)).

So this PR changes the default arithmetic to wrapping. This increases the risk of not noticing the overflow, but improves the consistency of the arithmetic rules.

```julia
julia> 1N0f8 * 1N0f8 # N0f8, N0f16, N0f32 and N0f64 are not affected by this change because they do not cause overflow
1.0N0f8

julia> 3N4f12 * 7N4f12 # v0.8
ERROR: ArgumentError: Normed{UInt16,12} is a 16-bit type representing 65536 values from 0.0 to 16.0037; cannot represent 21.0

julia> 3N4f12 * 7N4f12 # w/o this PR
ERROR: OverflowError: 3.0N4f12 * 7.0N4f12 overflowed for type N4f12

julia> 3N4f12 * 7N4f12 # with this PR
4.9961N4f12
```

You can still use checked arithmetic explicitly.
```julia
julia> using Base.Checked

julia> checked_mul(3N4f12, 7N4f12)
ERROR: OverflowError: 3.0N4f12 * 7.0N4f12 overflowed for type N4f12
```