### PR TITLE
Customize `print` to provide "plain" representation

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -727,6 +727,10 @@ end
     @test str == "-0.672Q0f7"
     @test eval(Meta.parse(str)) === q0f7
 
+    print(iob, q0f7)
+    str = String(take!(iob))
+    @test str == "-0.672" # w/o type suffix
+
     q15f16 = reinterpret(Q15f16, signed(0xaaaaaaaa))
     show(iob, q15f16)
     str = String(take!(iob))

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -699,6 +699,10 @@ end
     @test str == "0.667N0f8"
     @test eval(Meta.parse(str)) === n0f8
 
+    print(iob, n0f8)
+    str = String(take!(iob))
+    @test str == "0.667" # w/o type suffix
+
     n16f16 = reinterpret(N16f16, 0xaaaaaaaa)
     show(iob, n16f16)
     str = String(take!(iob))


### PR DESCRIPTION
`print` writes the number without the type suffix.
This also unifies the return values of `show`/`showtype` to `nothing`.

Closes #241 