### PR TITLE
Work around rounding errors in nightly test

### DIFF
--- a/test/normed.jl
+++ b/test/normed.jl
@@ -227,7 +227,8 @@ end
             T = rawtype(N)
             float_err = zero(Tf)
             for i = typemin(T):typemax(T)
-                f_expected = Tf(i / BigFloat(FixedPointNumbers.rawone(N)))
+                b_expected = i / BigFloat(FixedPointNumbers.rawone(N))
+                f_expected = Tf(promote_type(Tf, Float32)(b_expected)) # workaround for issue #246
                 isinf(f_expected) && break # for Float16(::Normed{UInt16,1})
                 f_actual = Tf(reinterpret(N, i))
                 float_err += abs(f_actual - f_expected)
@@ -238,7 +239,8 @@ end
             T = rawtype(N)
             error_count = 0
             for i in vcat(T(0x00):T(0xFF), (typemax(T)-0xFF):typemax(T))
-                f_expected = Tf(i / BigFloat(FixedPointNumbers.rawone(N)))
+                b_expected = i / BigFloat(FixedPointNumbers.rawone(N))
+                f_expected = Tf(promote_type(Tf, Float32)(b_expected)) # workaround for issue #246
                 isinf(f_expected) && break # for Float16() and Float32()
                 f_actual = Tf(reinterpret(N, i))
                 f_actual == f_expected && continue


### PR DESCRIPTION
This forces the `BigFloat`-->`Float16` conversion to go through `Float32` instead of `Float64`.:confused:

The nightly build also seems to have inference issues. I am going to make a separate PR.

Closes #246