### PR TITLE
Work around inference failure in promotion on nightly

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -540,8 +540,8 @@ function promote_rule(::Type{X1}, ::Type{X2}) where {T1, f1, X1 <: FixedPoint{T1
     m = max(nbitsint(X1), nbitsint(X2))
     _widen_rawtype(X{T,f}, m)
 end
-
-function _widen_rawtype(::Type{X}, m) where {T, f, X<:FixedPoint{T,f}}
+# TODO: avoid using @pure
+@pure function _widen_rawtype(::Type{X}, m) where {T, f, X<:FixedPoint{T,f}}
     nbitsint(X) >= m && return X
     Tw = widen1(T)
     T === Tw && return X


### PR DESCRIPTION
This is a first aid, as I prefer not to use `@pure` or `@generated`.
I will check this again before the release of Julia v1.7 or FixedPointNumbers v0.9.