### PR TITLE
using Requires for Statistics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ version = "0.8.4"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+Requires = "1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Because Statistics is no longer part of the Julia sysimage, the package loading
time of FixedPointNumbers is then donimated by Statistics. This commit uses
Requires to conditionally add the needed method without making more one-line
package. This, of course, adds some additional overhead but I do believe it's
currently the best tradeoff until we have first-class support on conditional
package loading.