### PR TITLE
use Random explicitly

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,3 +1,5 @@
+using Random
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     normedtypes = (N0f8, N0f16)                      # precompiled Normed types


### PR DESCRIPTION
In Julia 1.11 some work has been done to move standard libraries out of the "sysimage" and also make them upgradable (so they would no longer be strongly tied to the Julia version).
The Random stdlib is a bit special in the sense that it commits "type piracy" by overloading the `Base.rand` function for types that it doesn't own. An example of that is `rand()` which is defined in `Random`.
While code will still be able to call `rand(`) etc in 1.11 without loading `Random` there are some performance implications that makes it so it is better to load `Random` up front.

