### PR TITLE
Use `StableRNG` in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 FixedPointNumbersStatisticsExt = "Statistics"
 
 [compat]
+StableRNGs = "1"
 # Update this version specifier when Statistics.jl v1.11.2 is released.
 # https://github.com/JuliaStats/Statistics.jl/issues/165
 Statistics = "< 1.11.2"
@@ -20,8 +21,9 @@ julia = "1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "Statistics", "Test"]
+test = ["Documenter", "StableRNGs", "Statistics", "Test"]

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Statistics, Random, Test
+using FixedPointNumbers, Statistics, Random, StableRNGs, Test
 using FixedPointNumbers: bitwidth, rawtype, nbitsfrac
 using Base.Checked
 

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -677,7 +677,8 @@ end
 
 @testset "rand" begin
     test_rand(Fixed)
-    @test rand(MersenneTwister(1234), Q0f7) === -0.156Q0f7
+    @test !(rand(Q0f15) == rand(Q0f15) == rand(Q0f15)) # If this fails, we should suspect a bug.
+    @test rand(StableRNG(1234), Q0f7) === 0.531Q0f7
 end
 
 @testset "Promotion within Fixed" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -650,7 +650,8 @@ end
 
 @testset "rand" begin
     test_rand(Normed)
-    @test rand(MersenneTwister(1234), N0f8) === 0.925N0f8
+    @test !(rand(N0f16) == rand(N0f16) == rand(N0f16)) # If this fails, we should suspect a bug.
+    @test rand(StableRNG(1234), N0f8) === 0.267N0f8
 end
 
 @testset "Promotion within Normed" begin


### PR DESCRIPTION
Although reproducibility was not guaranteed, the output of `MersenneTwister` seems to have changed.

Note that `rand(StableRNG(1234), T)` is not a test for the generated random numbers, but for passing an RNG to the argument of `rand`.
On the other hand, since `StableRNGs` are not part of stdlib, I added the tests for the default RNG.