### PR TITLE
Fix test for exponentially growing `promote_type`

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -712,7 +712,13 @@ end
     @test @inferred(promote_type(Float32, Int, Q0f7)) === Float32
     @test @inferred(promote_type(Float32, Q0f7, Int)) === Float32
 
-    @test @inferred(promote_type(Q0f7,Q1f6,Q2f5,Q3f4,Q4f3,Q5f2)) == Fixed{Int128,7}
+    if promote_type(Int, Float32, Complex{Int}, typeof(pi)) === ComplexF64
+        # right-to-left
+        @test @inferred(promote_type(Q0f7, Q1f6, Q2f5, Q3f4, Q4f3, Q5f2)) == Fixed{Int128,7}
+    else
+        # left-to-right
+        @test @inferred(promote_type(Q5f2, Q4f3, Q3f4, Q2f5, Q1f6, Q0f7)) == Fixed{Int128,7}
+    end
 
     @test @inferred(promote_type(Q0f7, N0f32)) === Float64
 end

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -685,7 +685,13 @@ end
     @test @inferred(promote_type(Float32, Int, N0f8)) === Float32
     @test @inferred(promote_type(Float32, N0f8, Int)) === Float32
 
-    @test @inferred(promote_type(N0f8,N1f7,N2f6,N3f5,N4f4,N5f3)) === Normed{UInt128,8}
+    if promote_type(Int, Float32, Complex{Int}, typeof(pi)) === ComplexF64
+        # right-to-left
+        @test @inferred(promote_type(N0f8, N1f7, N2f6, N3f5, N4f4, N5f3)) === Normed{UInt128,8}
+    else
+        # left-to-right
+        @test @inferred(promote_type(N5f3, N4f4, N3f5, N2f6, N1f7, N0f8)) === Normed{UInt128,8}
+    end
 
     @test @inferred(promote_type(N0f8, Q0f31)) === Float64
 end


### PR DESCRIPTION
This follows the behavior, i.e. the order of evaluation, in `Base`.
It was changed recently in the nightly build (cf. https://github.com/JuliaLang/julia/pull/53665), and it might be changed further in the future.
```julia
julia> VERSION
v"1.12.0-DEV.283"

julia> promote_type(N0f8, N1f7, N2f6, N3f5, N4f4, N5f3)
N8f8 (alias for Normed{UInt16, 8})
```
I thought Julia was getting very smart, but that was not the case. 😆