### PR TITLE
Avoid multiple `include`s of "test/common.jl."

### DIFF
--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,4 +1,6 @@
-include("common.jl")
+if !isdefined(Main, :target)
+    include("common.jl")
+end
 
 function symbol_to_inttype(::Type{Fixed}, s::Symbol)
     d = Dict(:i8 => Int8, :i16 => Int16, :i32 => Int32, :i64 => Int64, :i128 => Int128)

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -1,4 +1,6 @@
-include("common.jl")
+if !isdefined(Main, :target)
+    include("common.jl")
+end
 
 function symbol_to_inttype(::Type{Normed}, s::Symbol)
     d = Dict(:i8 => UInt8, :i16 => UInt16, :i32 => UInt32, :i64 => UInt64, :i128 => UInt128)


### PR DESCRIPTION
I was aware of this problem from the beginning, but it was not important at the time.
I fix this as the recent julia shows warnings.