### PR TITLE
Add workaround for julia-invalidations

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -21,6 +21,18 @@ jobs:
         version: '1'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
+    - name: Overwrite Package Version # FIXME
+      run: >
+        julia -e '
+          lines = readlines("Project.toml")
+          open("Project.toml", "w") do f
+              for l in lines
+                  if l == "version = \"0.9.0-dev\""
+                      l = "version = \"0.8.4\""
+                  end
+                  println(f, l)
+              end
+          end'
     - uses: julia-actions/julia-invalidations@v1
       id: invs_pr
 
@@ -28,9 +40,21 @@ jobs:
       with:
         ref: ${{ github.event.repository.default_branch }}
     - uses: julia-actions/julia-buildpkg@v1
+    - name: Overwrite Package Version # FIXME
+      run: >
+        julia -e '
+          lines = readlines("Project.toml")
+          open("Project.toml", "w") do f
+              for l in lines
+                  if l == "version = \"0.9.0-dev\""
+                      l = "version = \"0.8.4\""
+                  end
+                  println(f, l)
+              end
+          end'
     - uses: julia-actions/julia-invalidations@v1
       id: invs_default
-    
+
     - name: Report invalidation counts
       run: |
         echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This is very ugly, but it is better than not being able to use the check.

xref: https://github.com/julia-actions/julia-invalidations/issues/17

Another possible method is to use git, but directly overwriting ”Project.toml” is simpler and somewhat more reliable.