### PR TITLE
Update macOS test targets

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -1,11 +1,11 @@
 name: Unit test
 
 on:
-  create:
-    tags:
   push:
     branches:
       - master
+      - release-*
+    tags: ['*']
   pull_request:
 
 jobs:
@@ -14,14 +14,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1', '1.6', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        julia-version: ['1.0', '1.6', '1', 'nightly']
+        os: [ubuntu-latest, windows-latest, macos-13]
         julia-arch: [x64]
-        # only test one 32-bit job
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-latest # only test one 32-bit job
             julia-version: '1'
             julia-arch: x86
+          - os: macos-latest
+            julia-version: '1'
+            julia-arch: aarch64
+          - os: macos-latest
+            julia-version: 'nightly'
+            julia-arch: aarch64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/UnitTestArm.yml
+++ b/.github/workflows/UnitTestArm.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1', '1.6', 'nightly']
+        julia-version: ['1.0', '1.6', '1', 'nightly']
         os: [ubuntu-latest]
         distro: [ubuntu_latest]
         arch: [aarch64]
@@ -50,7 +50,7 @@ jobs:
           tar -xf /tmp/julia-aarch64.tar.gz --strip-components=1 -C /home/runner/work/julia/
           rm /tmp/julia-aarch64.tar.gz
 
-      - uses: uraimo/run-on-arch-action@v2.7.1
+      - uses: uraimo/run-on-arch-action@v2.7.2
         name: Unit Test
         with:
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
Recently, GitHub-hosted runner `macos-latest` moved from `macos-12` to `macos-14`.
`macos-14` image runs on the 3 vCPU M1 (i.e., aarch64) runner.
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

So this sets up `macos-13` as the conventional macOS for x86-64, and adds new `macos-latest` targets for julia v1 and nightly (aarch64).
Unfortunately, julia v1.6 does not support M1 macOS. It looks like we will still need QEMU for a while.