### PR TITLE
Fix `_unsafe_trunc` to reduce the likelihood of arbitrary values

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -42,14 +42,14 @@ _unsafe_trunc(::Type{T}, x) where {T} = unsafe_trunc(T, x)
 # issue #202, #211
 _unsafe_trunc(::Type{T}, x::BigFloat) where {T <: Integer} = trunc(BigInt, x) % T
 
-if !signbit(signed(unsafe_trunc(UInt, -12.345)))
-    # a workaround for ARM (issue #134)
-    function _unsafe_trunc(::Type{T}, x::AbstractFloat) where {T <: Integer}
-        if T === UInt32
-            copysign(unsafe_trunc(T, abs(x)), x)
-        else
-            unsafe_trunc(T, unsafe_trunc(signedtype(T), x))
-        end
+# issue #288
+function _unsafe_trunc(::Type{T}, x::AbstractFloat) where {T <: Integer}
+    if T <: ShortInts
+        return unsafe_trunc(Int32, x) % T
+    elseif T <: Unsigned
+        return copysign(unsafe_trunc(T, abs(x)), x)
+    else
+        return unsafe_trunc(T, x)
     end
 end
 

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -31,20 +31,8 @@ end
 issue288_out = String(take!(buf))
 
 @testset "issue288" begin
-    expected_issue288 = "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
-    if issue288_in == expected_issue288 # just leave it in the report
-        @test issue288_in == expected_issue288
-    else
-        @test_broken issue288_in == expected_issue288
-        @warn """broken: "$issue288_in"\nexpected: "$expected_issue288" """
-    end
-    expected_issue288 = "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
-    if issue288_out == expected_issue288 # just leave it in the report
-        @test issue288_out == expected_issue288
-    else
-        @test_broken issue288_out == expected_issue288
-        @warn """broken: "$issue288_out"\nexpected: "$expected_issue288" """
-    end
+    @test issue288_in == "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
+    @test issue288_out == "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
 end
 
 function test_op(fun::Fun, fx::F, fy::F, fxf, fyf, tol) where {Fun, F}

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -31,20 +31,8 @@ end
 issue288_out = String(take!(buf))
 
 @testset "issue288" begin
-    expected_issue288 = "1.0N0f8 1.0N0f16 1.0N0f16 1.0N0f8 "
-    if issue288_in == expected_issue288 # just leave it in the report
-        @test issue288_in == expected_issue288
-    else
-        @test_broken issue288_in == expected_issue288
-        @warn """broken: "$issue288_in"\nexpected: "$expected_issue288" """
-    end
-    expected_issue288 = "0.004N0f8 2.0e-5N0f16 2.0e-5N0f16 0.004N0f8 "
-    if issue288_out == expected_issue288 # just leave it in the report
-        @test issue288_out == expected_issue288
-    else
-        @test_broken issue288_out == expected_issue288
-        @warn """broken: "$issue288_out"\nexpected: "$expected_issue288" """
-    end
+    @test issue288_in == "1.0N0f8 1.0N0f16 1.0N0f16 1.0N0f8 "
+    @test issue288_out == "0.004N0f8 2.0e-5N0f16 2.0e-5N0f16 0.004N0f8 "
 end
 
 @testset "domain of f" begin


### PR DESCRIPTION
This fixes (mitigates) #288.