### PR TITLE
[RFC] Move arithmetic functions into submodule `FixedPointArithmetic`

### DIFF
--- a/src/arithmetic/arithmetic.jl
+++ b/src/arithmetic/arithmetic.jl
@@ -1,0 +1,246 @@
+module FixedPointArithmetic
+
+import Base: -, +, *, /, abs, div, fld, cld, rem, mod
+
+import ..FixedPointNumbers
+using FixedPointNumbers: FixedPoint
+using FixedPointNumbers.Utilities
+
+export mul_with_rounding
+
+"""
+    Wrapping
+
+Submodule for wrapping arithmetic
+"""
+module Wrapping
+
+import ..FixedPointNumbers
+using FixedPointNumbers: FixedPoint
+using FixedPointNumbers.Utilities
+
+export wrapping_neg, wrapping_abs, wrapping_add, wrapping_sub, wrapping_mul
+export wrapping_div, wrapping_fld, wrapping_cld, wrapping_rem, wrapping_mod
+export wrapping_fdiv
+
+wrapping_neg(x::X) where {X <: FixedPoint} = X(-x.i, 0)
+wrapping_abs(x::X) where {X <: FixedPoint} = X(abs(x.i), 0)
+wrapping_add(x::X, y::X) where {X <: FixedPoint} = X(x.i + y.i, 0)
+wrapping_sub(x::X, y::X) where {X <: FixedPoint} = X(x.i - y.i, 0)
+wrapping_mul(x::X, y::X) where {X <: FixedPoint} = (float(x) * float(y)) % X
+function wrapping_fdiv(x::X, y::X) where {X <: FixedPoint}
+    z = floattype(X)(x.i) / floattype(X)(y.i)
+    isfinite(z) ? z % X : zero(X)
+end
+function wrapping_div(x::X, y::X, r::RoundingMode=RoundToZero) where {T,X <: FixedPoint{T}}
+    z = round(floattype(X)(x.i) / floattype(X)(y.i), r)
+    isfinite(z) || return zero(T)
+    if T <: Unsigned
+        _unsafe_trunc(T, z)
+    else
+        z > typemax(T) ? typemin(T) : _unsafe_trunc(T, z)
+    end
+end
+wrapping_fld(x::X, y::X) where {X <: FixedPoint} = wrapping_div(x, y, RoundDown)
+wrapping_cld(x::X, y::X) where {X <: FixedPoint} = wrapping_div(x, y, RoundUp)
+wrapping_rem(x::X, y::X, r::RoundingMode=RoundToZero) where {T,X <: FixedPoint{T}} =
+    X(x.i - wrapping_div(x, y, r) * y.i, 0)
+wrapping_mod(x::X, y::X) where {X <: FixedPoint} = wrapping_rem(x, y, RoundDown)
+
+end # module Wrapping
+
+"""
+    Saturating
+
+Submodule for saturating arithmetic
+"""
+module Saturating
+
+import ..FixedPointNumbers
+using FixedPointNumbers: FixedPoint
+using FixedPointNumbers.Utilities
+
+export saturating_neg, saturating_abs, saturating_add, saturating_sub, saturating_mul
+export saturating_div, saturating_fld, saturating_cld, saturating_rem, saturating_mod
+export saturating_fdiv
+
+saturating_neg(x::X) where {X <: FixedPoint} = X(~min(x.i - true, x.i), 0)
+saturating_neg(x::X) where {X <: FixedPoint{<:Unsigned}} = zero(X)
+
+saturating_abs(x::X) where {X <: FixedPoint} =
+    X(ifelse(signbit(abs(x.i)), typemax(x.i), abs(x.i)), 0)
+
+saturating_add(x::X, y::X) where {X <: FixedPoint} =
+    X(x.i + ifelse(x.i < 0, max(y.i, typemin(x.i) - x.i), min(y.i, typemax(x.i) - x.i)), 0)
+saturating_add(x::X, y::X) where {X <: FixedPoint{<:Unsigned}} = X(x.i + min(~x.i, y.i), 0)
+
+saturating_sub(x::X, y::X) where {X <: FixedPoint} =
+    X(x.i - ifelse(x.i < 0, min(y.i, x.i - typemin(x.i)), max(y.i, x.i - typemax(x.i))), 0)
+saturating_sub(x::X, y::X) where {X <: FixedPoint{<:Unsigned}} = X(x.i - min(x.i, y.i), 0)
+
+saturating_mul(x::X, y::X) where {X <: FixedPoint} = clamp(float(x) * float(y), X)
+
+saturating_fdiv(x::X, y::X) where {X <: FixedPoint} =
+    clamp(floattype(X)(x.i) / floattype(X)(y.i), X)
+
+function saturating_div(x::X, y::X, r::RoundingMode=RoundToZero) where {T, X <: FixedPoint{T}}
+    z = round(floattype(X)(x.i) / floattype(X)(y.i), r)
+    isnan(z) && return zero(T)
+    if T <: Unsigned
+        isfinite(z) ? _unsafe_trunc(T, z) : typemax(T)
+    else
+        _unsafe_trunc(T, clamp(z, typemin(T), typemax(T)))
+    end
+end
+saturating_fld(x::X, y::X) where {X <: FixedPoint} = saturating_div(x, y, RoundDown)
+saturating_cld(x::X, y::X) where {X <: FixedPoint} = saturating_div(x, y, RoundUp)
+function saturating_rem(x::X, y::X, r::RoundingMode=RoundToZero) where {T, X <: FixedPoint{T}}
+    T <: Unsigned && r isa RoundingMode{:Up} && return zero(X)
+    X(x.i - saturating_div(x, y, r) * y.i, 0)
+end
+saturating_mod(x::X, y::X) where {X <: FixedPoint} = saturating_rem(x, y, RoundDown)
+
+end # module Saturating
+
+"""
+    CheckedArithMetic
+"""
+module Checked
+
+import ..FixedPointNumbers
+using FixedPointNumbers: FixedPoint, showtype
+using FixedPointNumbers.Utilities
+
+import Base.Checked: checked_neg, checked_abs, checked_add, checked_sub, checked_mul
+import Base.Checked: checked_div, checked_fld, checked_cld, checked_rem, checked_mod
+
+export checked_neg, checked_abs, checked_add, checked_sub, checked_mul
+export checked_div, checked_fld, checked_cld, checked_rem, checked_mod
+export checked_fdiv
+
+checked_neg(x::X) where {X <: FixedPoint} = checked_sub(zero(X), x)
+function checked_abs(x::X) where {X <: FixedPoint}
+    abs(x.i) >= 0 || throw_overflowerror_abs(x)
+    X(abs(x.i), 0)
+end
+function checked_add(x::X, y::X) where {X <: FixedPoint}
+    r, f = Base.Checked.add_with_overflow(x.i, y.i)
+    z = X(r, 0) # store first
+    f && throw_overflowerror(:+, x, y)
+    z
+end
+function checked_sub(x::X, y::X) where {X <: FixedPoint}
+    r, f = Base.Checked.sub_with_overflow(x.i, y.i)
+    z = X(r, 0) # store first
+    f && throw_overflowerror(:-, x, y)
+    z
+end
+function checked_mul(x::X, y::X) where {X <: FixedPoint}
+    z = float(x) * float(y)
+    typemin(X) - eps(X) / 2 <= z < typemax(X) + eps(X) / 2 || throw_overflowerror(:*, x, y)
+    z % X
+end
+function checked_fdiv(x::X, y::X) where {T,X <: FixedPoint{T}}
+    y === zero(X) && throw(DivideError())
+    z = floattype(X)(x.i) / floattype(X)(y.i)
+    if T <: Unsigned
+        z < typemax(X) + eps(X) / 2 || throw_overflowerror(:/, x, y)
+    else
+        typemin(X) - eps(X) / 2 <= z < typemax(X) + eps(X) / 2 || throw_overflowerror(:/, x, y)
+    end
+    z % X
+end
+function checked_div(x::X, y::X, r::RoundingMode=RoundToZero) where {T, X <: FixedPoint{T}}
+    y === zero(X) && throw(DivideError())
+    z = round(floattype(X)(x.i) / floattype(X)(y.i), r)
+    if T <: Signed
+        z <= typemax(T) || throw_overflowerror_div(r, x, y)
+    end
+    _unsafe_trunc(T, z)
+end
+checked_fld(x::X, y::X) where {X <: FixedPoint} = checked_div(x, y, RoundDown)
+checked_cld(x::X, y::X) where {X <: FixedPoint} = checked_div(x, y, RoundUp)
+function checked_rem(x::X, y::X, r::RoundingMode=RoundToZero) where {T, X <: FixedPoint{T}}
+    y === zero(X) && throw(DivideError())
+    fx, fy = floattype(X)(x.i), floattype(X)(y.i)
+    z = fx - round(fx / fy, r) * fy
+    if T <: Unsigned && r isa RoundingMode{:Up}
+        z >= zero(z) || throw_overflowerror_rem(r, x, y)
+    end
+    X(_unsafe_trunc(T, z), 0)
+end
+checked_mod(x::X, y::X) where {X <: FixedPoint} = checked_rem(x, y, RoundDown)
+
+@noinline function throw_overflowerror(op::Symbol, @nospecialize(x), @nospecialize(y))
+    io = IOBuffer()
+    print(io, x, ' ', op, ' ', y, " overflowed for type ")
+    showtype(io, typeof(x))
+    throw(OverflowError(String(take!(io))))
+end
+@noinline function throw_overflowerror_abs(@nospecialize(x))
+    io = IOBuffer()
+    print(io, "abs(", x, ") overflowed for type ")
+    showtype(io, typeof(x))
+    throw(OverflowError(String(take!(io))))
+end
+@noinline function throw_overflowerror_div(r::RoundingMode, @nospecialize(x), @nospecialize(y))
+    io = IOBuffer()
+    op = r === RoundUp ? "cld(" : r === RoundDown ? "fld(" : "div("
+    print(io, op, x, ", ", y, ") overflowed for type ", rawtype(x))
+    throw(OverflowError(String(take!(io))))
+end
+@noinline function throw_overflowerror_rem(r::RoundingMode, @nospecialize(x), @nospecialize(y))
+    io = IOBuffer()
+    print(io, "rem(", x, ", ", y, ", ", r, ") overflowed for type ", typeof(x))
+    throw(OverflowError(String(take!(io))))
+end
+
+end # module Checked
+
+using .Wrapping
+using .Saturating
+using .Checked
+
+using .Checked: throw_overflowerror
+
+# re-export
+for name in names(Wrapping)
+    @eval export $name
+end
+for name in names(Saturating)
+    @eval export $name
+end
+for name in names(Checked)
+    @eval export $name
+end
+
+include("normed_arithmetic.jl")
+include("fixed_arithmetic.jl")
+
+# default arithmetic
+const DEFAULT_ARITHMETIC = :wrapping
+
+for (op, name) in ((:-, :neg), (:abs, :abs))
+    f = Symbol(DEFAULT_ARITHMETIC, :_, name)
+    @eval begin
+        $op(x::X) where {X <: FixedPoint} = $f(x)
+    end
+end
+for (op, name) in ((:+, :add), (:-, :sub), (:*, :mul))
+    f = Symbol(DEFAULT_ARITHMETIC, :_, name)
+    @eval begin
+        $op(x::X, y::X) where {X <: FixedPoint} = $f(x, y)
+    end
+end
+
+# force checked arithmetic
+/(x::X, y::X) where {X <: FixedPoint} = checked_fdiv(x, y)
+div(x::X, y::X, r::RoundingMode=RoundToZero) where {X <: FixedPoint} = checked_div(x, y, r)
+fld(x::X, y::X) where {X <: FixedPoint} = checked_div(x, y, RoundDown)
+cld(x::X, y::X) where {X <: FixedPoint} = checked_div(x, y, RoundUp)
+rem(x::X, y::X) where {X <: FixedPoint} = checked_rem(x, y, RoundToZero)
+rem(x::X, y::X, ::RoundingMode{:Down}) where {X <: FixedPoint} = checked_rem(x, y, RoundDown)
+rem(x::X, y::X, ::RoundingMode{:Up}) where {X <: FixedPoint} = checked_rem(x, y, RoundUp)
+mod(x::X, y::X) where {X <: FixedPoint} = checked_rem(x, y, RoundDown)
+
+end # module FixedPointArithmetic

--- a/src/arithmetic/fixed_arithmetic.jl
+++ b/src/arithmetic/fixed_arithmetic.jl
@@ -1,0 +1,48 @@
+using FixedPointNumbers: Fixed
+import .Wrapping: wrapping_mul
+import .Saturating: saturating_mul
+import .Checked: checked_mul
+
+# wrapping arithmetic
+function wrapping_mul(x::F, y::F) where {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T,f}}
+    z = widemul(x.i, y.i)
+    F(div_2f(z, Val(Int(f))) % T, 0)
+end
+
+# saturating arithmetic
+function saturating_mul(x::F, y::F) where {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T,f}}
+    if f >= bitwidth(T) - 1
+        z = min(widemul(x.i, y.i), widen1(typemax(T)) << f)
+    else
+        z = clamp(widemul(x.i, y.i), widen1(typemin(T)) << f, widen1(typemax(T)) << f)
+    end
+    F(div_2f(z, Val(Int(f))) % T, 0)
+end
+
+# checked arithmetic
+function checked_mul(x::F, y::F) where {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T,f}}
+    z = widemul(x.i, y.i)
+    if f < 1
+        m = widen1(typemax(T)) + 0x1
+        n = widen1(typemin(T))
+    else
+        half = widen1(oneunit(T)) << (f - 1)
+        m = widen1(typemax(T)) << f + half
+        n = widen1(typemin(T)) << f - half
+    end
+    (n <= z) & (z < m) || throw_overflowerror(:*, x, y)
+    F(div_2f(z, Val(Int(f))) % T, 0)
+end
+
+function mul_with_rounding(x::F, y::F, ::RoundingMode{:Nearest}) where {F <: Fixed}
+    wrapping_mul(x, y)
+end
+function mul_with_rounding(x::F, y::F, ::RoundingMode{:NearestTiesUp}) where
+{T<:Union{Int8,Int16,Int32,Int64},f,F <: Fixed{T,f}}
+    z = widemul(x.i, y.i)
+    F(((z + (oftype(z, 1) << f >>> 1)) >> f) % T, 0)
+end
+function mul_with_rounding(x::F, y::F, ::RoundingMode{:Down}) where
+{T<:Union{Int8,Int16,Int32,Int64},f,F <: Fixed{T,f}}
+    F((widemul(x.i, y.i) >> f) % T, 0)
+end

--- a/src/arithmetic/normed_arithmetic.jl
+++ b/src/arithmetic/normed_arithmetic.jl
@@ -1,0 +1,31 @@
+using FixedPointNumbers: Normed
+import .Wrapping: wrapping_mul
+import .Saturating: saturating_mul
+import .Checked: checked_mul
+
+# wrapping arithmetic
+function wrapping_mul(x::N, y::N) where {T <: Union{UInt8,UInt16,UInt32,UInt64}, f, N <: Normed{T,f}}
+    z = widemul(x.i, y.i)
+    N(div_2fm1(z, Val(Int(f))) % T, 0)
+end
+
+# saturating arithmetic
+function saturating_mul(x::N, y::N) where {T <: Union{UInt8,UInt16,UInt32,UInt64}, f, N <: Normed{T,f}}
+    f == bitwidth(T) && return wrapping_mul(x, y)
+    z = min(widemul(x.i, y.i), widemul(typemax(N).i, rawone(N)))
+    N(div_2fm1(z, Val(Int(f))) % T, 0)
+end
+
+# checked arithmetic
+function checked_mul(x::N, y::N) where {N <: Normed}
+    z = float(x) * float(y)
+    z < typemax(N) + eps(N) / 2 || throw_overflowerror(:*, x, y)
+    z % N
+end
+function checked_mul(x::N, y::N) where {T <: Union{UInt8,UInt16,UInt32,UInt64}, f, N <: Normed{T,f}}
+    f == bitwidth(T) && return wrapping_mul(x, y)
+    z = widemul(x.i, y.i)
+    m = widemul(typemax(N).i, rawone(N)) + (rawone(N) >> 0x1)
+    z < m || throw_overflowerror(:*, x, y)
+    N(div_2fm1(z, Val(Int(f))) % T, 0)
+end

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -127,59 +127,6 @@ function Base.Rational(x::Fixed{T,f}) where {T, f}
     f < bitwidth(T)-1 ? x.i//rawone(x) : x.i//(one(widen1(T))<<f)
 end
 
-function div_2f(x::T, ::Val{f}) where {T, f}
-    xf = x & (T(-1) >>> (bitwidth(T) - f - 1))
-    half = oneunit(T) << (f - 1)
-    c = half - (xf === half)
-    (x + c) >> f
-end
-div_2f(x::T, ::Val{0}) where {T} = x
-
-# wrapping arithmetic
-function wrapping_mul(x::F, y::F) where {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T,f}}
-    z = widemul(x.i, y.i)
-    F(div_2f(z, Val(Int(f))) % T, 0)
-end
-
-# saturating arithmetic
-function saturating_mul(x::F, y::F) where {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T,f}}
-    if f >= bitwidth(T) - 1
-        z = min(widemul(x.i, y.i), widen1(typemax(T)) << f)
-    else
-        z = clamp(widemul(x.i, y.i), widen1(typemin(T)) << f, widen1(typemax(T)) << f)
-    end
-    F(div_2f(z, Val(Int(f))) % T, 0)
-end
-
-# checked arithmetic
-function checked_mul(x::F, y::F) where {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T,f}}
-    z = widemul(x.i, y.i)
-    if f < 1
-        m = widen1(typemax(T)) + 0x1
-        n = widen1(typemin(T))
-    else
-        half = widen1(oneunit(T)) << (f - 1)
-        m = widen1(typemax(T)) << f + half
-        n = widen1(typemin(T)) << f - half
-    end
-    (n <= z) & (z < m) || throw_overflowerror(:*, x, y)
-    F(div_2f(z, Val(Int(f))) % T, 0)
-end
-
-function mul_with_rounding(x::F, y::F, ::RoundingMode{:Nearest}) where {F <: Fixed}
-    wrapping_mul(x, y)
-end
-function mul_with_rounding(x::F, y::F, ::RoundingMode{:NearestTiesUp}) where
-                          {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T, f}}
-    z = widemul(x.i, y.i)
-    F(((z + (oftype(z, 1) << f >>> 1)) >> f) % T, 0)
-end
-function mul_with_rounding(x::F, y::F, ::RoundingMode{:Down}) where
-                          {T <: Union{Int8,Int16,Int32,Int64}, f, F <: Fixed{T, f}}
-    F((widemul(x.i, y.i) >> f) % T, 0)
-end
-
-
 function trunc(x::Fixed{T,f}) where {T, f}
     f == 0 && return x
     f == bitwidth(T) && return zero(x) # TODO: remove this line

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -253,41 +253,6 @@ Base.BigFloat(x::Normed) = reinterpret(x) / BigFloat(rawone(x))
 
 Base.Rational(x::Normed) = reinterpret(x)//rawone(x)
 
-# Division by `2^f-1` with RoundNearest. The result would be in the lower half bits.
-div_2fm1(x::T, ::Val{f}) where {T, f} = (x + (T(1)<<(f - 1) - 0x1)) ÷ (T(1) << f - 0x1)
-div_2fm1(x::T, ::Val{1}) where T = x
-div_2fm1(x::UInt16,  ::Val{8})  = (((x + 0x80) >> 0x8) + x + 0x80) >> 0x8
-div_2fm1(x::UInt32,  ::Val{16}) = (((x + 0x8000) >> 0x10) + x + 0x8000) >> 0x10
-div_2fm1(x::UInt64,  ::Val{32}) = (((x + 0x80000000) >> 0x20) + x + 0x80000000) >> 0x20
-div_2fm1(x::UInt128, ::Val{64}) = (((x + 0x8000000000000000) >> 0x40) + x + 0x8000000000000000) >> 0x40
-
-# wrapping arithmetic
-function wrapping_mul(x::N, y::N) where {T <: Union{UInt8,UInt16,UInt32,UInt64}, f, N <: Normed{T,f}}
-    z = widemul(x.i, y.i)
-    N(div_2fm1(z, Val(Int(f))) % T, 0)
-end
-
-# saturating arithmetic
-function saturating_mul(x::N, y::N) where {T <: Union{UInt8,UInt16,UInt32,UInt64}, f, N <: Normed{T,f}}
-    f == bitwidth(T) && return wrapping_mul(x, y)
-    z = min(widemul(x.i, y.i), widemul(typemax(N).i, rawone(N)))
-    N(div_2fm1(z, Val(Int(f))) % T, 0)
-end
-
-# checked arithmetic
-function checked_mul(x::N, y::N) where {N <: Normed}
-    z = float(x) * float(y)
-    z < typemax(N) + eps(N)/2 || throw_overflowerror(:*, x, y)
-    z % N
-end
-function checked_mul(x::N, y::N) where {T <: Union{UInt8,UInt16,UInt32,UInt64}, f, N <: Normed{T,f}}
-    f == bitwidth(T) && return wrapping_mul(x, y)
-    z = widemul(x.i, y.i)
-    m = widemul(typemax(N).i, rawone(N)) + (rawone(N) >> 0x1)
-    z < m || throw_overflowerror(:*, x, y)
-    N(div_2fm1(z, Val(Int(f))) % T, 0)
-end
-
 
 # Functions
 floor(x::N) where {N <: Normed} = reinterpret(N, x.i - x.i % rawone(N))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,4 +1,35 @@
-# utility functions and macros, which are independent of `FixedPoint`
+"""
+Module for utility functions and macros, which are independent of `FixedPoint`.
+This also includes the declaration of public or internal APIs.
+"""
+module Utilities
+
+export ShortInts
+export LongInts
+export ShorterThanInt
+export NotBiggerThanInt
+export NotBiggerThanInt64
+export SShorterThanInt
+export UShorterThanInt
+
+export bitwidth, widen1, signedtype, wrapper
+export @f32, @exp2, significand_bits, exponent_bias
+export _unsafe_trunc
+export div_2f, div_2fm1
+
+export floattype, rawone, inv_rawone, nbitsfrac, rawtype, signbits, nbitsint
+export scaledual
+
+
+const ShortInts = Union{Int8, UInt8, Int16, UInt16}
+const LongInts = Union{Int64, UInt64, Int128, UInt128, BigInt}
+
+const ShorterThanInt = Int === Int32 ? ShortInts : Union{ShortInts, Int32, UInt32}
+const NotBiggerThanInt = Union{ShorterThanInt, Int, UInt}
+const NotBiggerThanInt64 = Union{ShortInts, Int32, UInt32, Int64, UInt64}
+const SShorterThanInt = typeintersect(ShorterThanInt, Signed)
+const UShorterThanInt = typeintersect(ShorterThanInt, Unsigned)
+
 bitwidth(T::Type) = 8sizeof(T)
 
 widen1(T::Type)         = T # fallback
@@ -14,14 +45,7 @@ widen1(x::Integer) = x % widen1(typeof(x))
 
 signedtype(::Type{T}) where {T <: Integer} = typeof(signed(zero(T)))
 
-const ShortInts = Union{Int8, UInt8, Int16, UInt16}
-const LongInts = Union{Int64, UInt64, Int128, UInt128, BigInt}
-
-const ShorterThanInt = Int === Int32 ? ShortInts : Union{ShortInts, Int32, UInt32}
-const NotBiggerThanInt = Union{ShorterThanInt, Int, UInt}
-const NotBiggerThanInt64 = Union{ShortInts, Int32, UInt32, Int64, UInt64}
-const SShorterThanInt = typeintersect(ShorterThanInt, Signed)
-const UShorterThanInt = typeintersect(ShorterThanInt, Unsigned)
+wrapper(@nospecialize(T)) = Base.typename(T).wrapper
 
 macro f32(x::Float64) # just for hexadecimal floating-point literals
     :(Float32($x))
@@ -53,4 +77,46 @@ function _unsafe_trunc(::Type{T}, x::AbstractFloat) where {T <: Integer}
     end
 end
 
-wrapper(@nospecialize(T)) = Base.typename(T).wrapper
+# Division by `2^f` with RoundNearest.
+function div_2f(x::T, ::Val{f}) where {T,f}
+    xf = x & (T(-1) >>> (bitwidth(T) - f - 1))
+    half = oneunit(T) << (f - 1)
+    c = half - (xf === half)
+    (x + c) >> f
+end
+div_2f(x::T, ::Val{0}) where {T} = x
+
+# Division by `2^f-1` with RoundNearest. The result would be in the lower half bits.
+div_2fm1(x::T, ::Val{f}) where {T,f} = (x + (T(1) << (f - 1) - 0x1)) ÷ (T(1) << f - 0x1)
+div_2fm1(x::T, ::Val{1}) where {T} = x
+div_2fm1(x::UInt16, ::Val{8}) = (((x + 0x80) >> 0x8) + x + 0x80) >> 0x8
+div_2fm1(x::UInt32, ::Val{16}) = (((x + 0x8000) >> 0x10) + x + 0x8000) >> 0x10
+div_2fm1(x::UInt64, ::Val{32}) = (((x + 0x80000000) >> 0x20) + x + 0x80000000) >> 0x20
+div_2fm1(x::UInt128, ::Val{64}) = (((x + 0x8000000000000000) >> 0x40) + x + 0x8000000000000000) >> 0x40
+
+
+
+floattype(::Type{T}) where {T<:AbstractFloat} = T # fallback (we want a MethodError if no method producing AbstractFloat is defined)
+floattype(::Type{T}) where {T<:Union{ShortInts,Bool}} = Float32
+floattype(::Type{T}) where {T<:Integer} = Float64
+floattype(::Type{T}) where {T<:LongInts} = BigFloat
+floattype(::Type{T}) where {I<:Integer,T<:Rational{I}} = typeof(zero(I) / oneunit(I))
+floattype(::Type{<:AbstractIrrational}) = Float64
+# Non-Real types
+floattype(::Type{Complex{T}}) where {T} = Complex{floattype(T)}
+floattype(::Type{Base.TwicePrecision{Float64}}) = Float64    # wider would be nice, but hardware support is paramount
+floattype(::Type{Base.TwicePrecision{T}}) where {T<:Union{Float16,Float32}} = widen(T)
+
+function rawone end
+
+# for Julia v1.0, which does not fold `div_float` before inlining
+inv_rawone(x) = (@generated) ? (y = 1.0 / rawone(x); :($y)) : 1.0 / rawone(x)
+
+function nbitsfrac end
+function rawtype end
+function signbits end
+function nbitsint end
+
+function scaledual end
+
+end # module Utilities


### PR DESCRIPTION
This is in preparation for improved overflow handling.  (closes #239)

We should probably discuss the module structure in OverflowContexts.jl.
xref: https://github.com/JuliaMath/OverflowContexts.jl/pull/7

---
Even though these functions will be exposed differently in the future by the package extension mechanism, I believe that their implementation should be there statically.

There is a slight tradeoff between an ideal module structure and maintainability.
The proposed file structure  follows the conventional file structure.
That is, the `FixedPoint` common implementations are in one `arithmetic.jl`, and the specializations specific to `Fixed` and `Normed` are in `*_arithmetic.jl`.

In terms of modularity, it might be better to have separate files for each strategy, such as `Checked`.
However, as noted above, I do not intend for them to be loaded/compiled independently.

Submodule names such as `Wrapping` are also debatable.
The current proposal comes from the following reasons:
- `CheckedArithmetic` conflicts with [the package](https://github.com/JuliaMath/CheckedArithmetic.jl) name
- `FixedPointCheckedArithmetic`, `FixedPointChecked`, and so on are redundant
  - They are never exported from `FixedPointNumbers`
- They are the analogy with `Base.Checked`


The automatic formatter has removed the spaces in the type parameters, which I will try to restore later.