### PR TITLE
Version 0.8.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,34 @@
 name = "FixedPointNumbers"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[weakdeps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[extensions]
+FixedPointNumbersStatisticsExt = "Statistics"
+
 [compat]
+Aqua = "0.8"
+Documenter = "0.27, 1"
+Random = "<0.0.1, 1"
+StableRNGs = "1"
+# Update this version specifier when Statistics.jl v1.11.2 is released.
+# https://github.com/JuliaStats/Statistics.jl/issues/165
+Statistics = "< 1.11.2"
+Test = "1"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Documenter", "StableRNGs", "Statistics", "Test"]


### PR DESCRIPTION
Backporting (PR #293) is largely complete.
Division `/` is inconsistent, but this is due to the existing implementation. （It should be improved in v0.9. #222）

I will now check on the impact on the downstream packages.