### PR TITLE
Backport "Use sampler-based Random API (#206)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,16 @@ uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.5"
 
 [deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+StableRNGs = "1"
 julia = "1"
 
 [extras]
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["StableRNGs", "Test"]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,3 +1,5 @@
+using Random
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     normedtypes = (N0f8, N0f16)                      # precompiled Normed types

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Statistics, Test
+using FixedPointNumbers, Statistics, Random, StableRNGs, Test
 using FixedPointNumbers: bitwidth
 
 # issue #288
@@ -404,6 +404,8 @@ end
         @test ndims(a) == 2 && eltype(a) == F
         @test size(a) == (3,5)
     end
+    @test !(rand(Q0f15) == rand(Q0f15) == rand(Q0f15)) # If this fails, we should suspect a bug.
+    @test rand(StableRNG(1234), Q0f7) === 0.531Q0f7
 end
 
 @testset "floatmin" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Statistics, Test
+using FixedPointNumbers, Statistics, Random, StableRNGs, Test
 using FixedPointNumbers: bitwidth
 
 # issue #288
@@ -595,6 +595,8 @@ end
         @test ndims(a) == 2 && eltype(a) == T
         @test size(a) == (3,5)
     end
+    @test !(rand(N0f16) == rand(N0f16) == rand(N0f16)) # If this fails, we should suspect a bug.
+    @test rand(StableRNG(1234), N0f8) === 0.267N0f8
 end
 
 @testset "Overflow with Float16" begin


### PR DESCRIPTION
This also backports the changes in PR #270, #278.