### PR TITLE
Backport "Remove assertions in "src/precompile.jl" (#254)"

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.0', '1.6', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest]
         julia-arch: [x64]
         include:
           - os: ubuntu-latest # only test one 32-bit job

--- a/.github/workflows/UnitTestArm.yml
+++ b/.github/workflows/UnitTestArm.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         julia-version: ['1.0', '1.6', '1', 'nightly']
         os: [ubuntu-latest]
-        distro: [ubuntu_latest]
+        distro: [ubuntu24.04]
         arch: [aarch64]
 
     steps:
@@ -51,8 +51,7 @@ jobs:
           mkdir -p /home/runner/work/julia/
           tar -xf /tmp/julia-aarch64.tar.gz --strip-components=1 -C /home/runner/work/julia/
           rm /tmp/julia-aarch64.tar.gz
-
-      - uses: uraimo/run-on-arch-action@v2.7.2
+      - uses: uraimo/run-on-arch-action@v3
         name: Unit Test
         with:
           arch: ${{ matrix.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedPointNumbers"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.5"
+version = "0.8.6"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,27 +6,27 @@ function _precompile_()
     realtypes = (Float16, Float32, Float64, Int)     # types for mixed Normed/Real operations
     for T in normedtypes
         for f in (+, -, abs, eps, rand)       # unary operations
-            @assert precompile(Tuple{typeof(f),T})
+            precompile(Tuple{typeof(f),T})
         end
-        @assert precompile(Tuple{typeof(rand),T,Tuple{Int}})
-        @assert precompile(Tuple{typeof(rand),T,Tuple{Int,Int}})
+        precompile(Tuple{typeof(rand),T,Tuple{Int}})
+        precompile(Tuple{typeof(rand),T,Tuple{Int,Int}})
         for f in (trunc, floor, ceil, round)  # rounding operations
-            @assert precompile(Tuple{typeof(f),T})
-            @assert precompile(Tuple{typeof(f),Type{Int},T})
+            precompile(Tuple{typeof(f),T})
+            precompile(Tuple{typeof(f),Type{Int},T})
         end
         for f in (+, -, *, /, <, <=, ==)      # binary operations
-            @assert precompile(Tuple{typeof(f),T,T})
+            precompile(Tuple{typeof(f),T,T})
             for S in realtypes
-                @assert precompile(Tuple{typeof(f),T,S})
-                @assert precompile(Tuple{typeof(f),S,T})
+                precompile(Tuple{typeof(f),T,S})
+                precompile(Tuple{typeof(f),S,T})
             end
         end
         # conversions
         for S in realtypes
-            @assert precompile(Tuple{Type{T},S})
-            @assert precompile(Tuple{Type{S},T})
-            @assert precompile(Tuple{typeof(convert),Type{T},S})
-            @assert precompile(Tuple{typeof(convert),Type{S},T})
+            precompile(Tuple{Type{T},S})
+            precompile(Tuple{Type{S},T})
+            precompile(Tuple{typeof(convert),Type{T},S})
+            precompile(Tuple{typeof(convert),Type{S},T})
         end
     end
 end


### PR DESCRIPTION
- Cherry-picked commit #59ee94b
- Bumped version number
- Removed macos-13 os from the matrix. No longer supported by actions.
- Updated arm action version, as the current on no longer works.