### PR TITLE
Support parsing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -1,0 +1,64 @@
+name: Invalidations
+
+on:
+  pull_request:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    # Only run on PRs to the default branch.
+    # In the PR trigger above branches can be specified only explicitly whereas this check should work for master, main, or any other default branch
+    if: github.base_ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: '1'
+    - uses: actions/checkout@v4
+    - uses: julia-actions/julia-buildpkg@v1
+    - name: Overwrite Package Version # FIXME
+      run: >
+        julia -e '
+          lines = readlines("Project.toml")
+          open("Project.toml", "w") do f
+              for l in lines
+                  if l == "version = \"0.9.0-dev\""
+                      l = "version = \"0.8.4\""
+                  end
+                  println(f, l)
+              end
+          end'
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_pr
+
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+    - uses: julia-actions/julia-buildpkg@v1
+    - name: Overwrite Package Version # FIXME
+      run: >
+        julia -e '
+          lines = readlines("Project.toml")
+          open("Project.toml", "w") do f
+              for l in lines
+                  if l == "version = \"0.9.0-dev\""
+                      l = "version = \"0.8.4\""
+                  end
+                  println(f, l)
+              end
+          end'
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_default
+
+    - name: Report invalidation counts
+      run: |
+        echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+        echo "This branch: ${{ steps.invs_pr.outputs.total }} (${{ steps.invs_pr.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+    - name: Check if the PR does increase number of invalidations
+      if: steps.invs_pr.outputs.total > steps.invs_default.outputs.total
+      run: exit 1

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,17 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  contents: write
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -1,14 +1,13 @@
 name: Unit test
 
 on:
-  create:
-    tags:
   push:
     branches:
       - master
+      - release-*
+    tags: ['*']
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -16,40 +15,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        julia-version: ['1.0', '1.6', '1', 'nightly']
+        os: [ubuntu-latest, windows-latest, macos-13]
         julia-arch: [x64]
-        # only test one 32-bit job
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-latest # only test one 32-bit job
             julia-version: '1'
             julia-arch: x86
+          - os: macos-latest
+            julia-version: '1'
+            julia-arch: aarch64
+          - os: macos-latest
+            julia-version: 'nightly'
+            julia-arch: aarch64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-
       - name: Cache artifacts
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts 
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+        uses: julia-actions/cache@v2
       - name: "Unit Test"
-        uses: julia-actions/julia-runtest@master
+        uses: julia-actions/julia-runtest@v1
 
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
           file: lcov.info
-            
-        

--- a/.github/workflows/UnitTestArm.yml
+++ b/.github/workflows/UnitTestArm.yml
@@ -1,0 +1,76 @@
+name: Unit test for Arm
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+permissions:
+  actions: write
+  contents: read
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['1.0', '1.6', '1', 'nightly']
+        os: [ubuntu-latest]
+        distro: [ubuntu_latest]
+        arch: [aarch64]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
+      - name: Download Julia Binary
+        run: >
+          julia -e '
+            using Pkg; Pkg.add("JSON"); using JSON;
+            if "${{ matrix.julia-version }}" == "nightly";
+              url = "https://julialangnightlies-s3.julialang.org/bin/linux/${{ matrix.arch }}/julia-latest-linux-${{ matrix.arch }}.tar.gz";
+            else;
+              path = download("https://julialang-s3.julialang.org/bin/versions.json");
+              json = JSON.parsefile(path);
+              try rm(path) catch end;
+              vspec = Pkg.Types.VersionSpec("${{ matrix.julia-version }}");
+              a(f) = f["arch"] == "${{ matrix.arch }}" && f["os"] == "linux" && !occursin("musl", f["triplet"]);
+              m = filter(json) do v; vn = VersionNumber(v[1]); vn in vspec && isempty(vn.prerelease) && any(a, v[2]["files"]); end;
+              v = sort(VersionNumber.(keys(m)))[end];
+              url = filter(a, json[string(v)]["files"])[1]["url"];
+            end;
+            download(url, "/tmp/julia-aarch64.tar.gz");'
+
+      - name: Extract Julia Files
+        run: |
+          mkdir -p /home/runner/work/julia/
+          tar -xf /tmp/julia-aarch64.tar.gz --strip-components=1 -C /home/runner/work/julia/
+          rm /tmp/julia-aarch64.tar.gz
+
+      - uses: uraimo/run-on-arch-action@v2.7.2
+        name: Unit Test
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          dockerRunArgs: |
+            -v "/home/runner/work/julia:/home/runner/work/julia"
+            -v "/home/runner/.julia/registries:/root/.julia/registries"
+            --net=host
+          install: |
+            ln -s /home/runner/work/julia/bin/julia /usr/local/bin/julia
+            echo /home/runner/work/julia/lib > /etc/ld.so.conf.d/julia.conf
+            mkdir -p /root/.julia/registries/General
+          run: |
+            julia --compile=min -O0 -e 'using InteractiveUtils; versioninfo();'
+            julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
+          file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,16 @@ uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.5"
 
 [deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+StableRNGs = "1"
 julia = "1"
 
 [extras]
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["StableRNGs", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedPointNumbers"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+JET = "0.9, 0.10, 0.11"
 StableRNGs = "1"
 julia = "1"
 
 [extras]
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "Test"]
+test = ["JET", "StableRNGs", "Test"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ To construct such a number, use `1.3N4f12`, `N4f12(1.3)`, `convert(N4f12, 1.3)`,
 `Normed{UInt16,12}(1.3)`, or `reinterpret(N4f12, 0x14cc)`.
 The last syntax means to construct a `N4f12` from the `UInt16` value `0x14cc`.
 
+To read a number from its textual representation, use `parse(N4f12, "1.3")`, or
+`tryparse(N4f12, "1.3")` which returns `nothing` instead of throwing when the
+string is malformed or out of range.
+
 More generally, an arbitrary number of bits from any of the standard unsigned
 integer widths can be used for the fractional part.  For example:
 `Normed{UInt32,16}`, `Normed{UInt64,3}`, `Normed{UInt128,7}`.

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -12,7 +12,7 @@ import Base: ==, <, <=, -, +, *, /, ~, isapprox,
 import Statistics   # for _mean_promote
 import Random: Random, AbstractRNG, SamplerType, rand!
 
-using Base.Checked: checked_add, checked_sub, checked_div
+using Base.Checked: checked_add, checked_sub, checked_mul, checked_div
 
 using Base: @pure
 
@@ -82,6 +82,71 @@ big(x::FixedPoint) = convert(BigFloat, x)
 rationalize(x::FixedPoint; tol::Real=eps(x)) = rationalize(Int, x, tol=tol)
 function rationalize(::Type{Ti}, x::FixedPoint; tol::Real=eps(x)) where Ti <: Integer
     tol <= eps(x) ? Rational{Ti}(x) : rationalize(Ti, float(x), tol)
+end
+
+# parsing
+
+# true if `cu[lo:hi]` is a nonempty run of ASCII decimal digits
+_alldigits(cu, lo::Int, hi::Int) = lo <= hi && all(UInt8('0') <= cu[i] <= UInt8('9') for i in lo:hi)
+
+# true if `cu[lo:hi]` is an optional sign followed by ASCII decimal digits
+_isdecint(cu, lo::Int, hi::Int) = lo <= hi && _alldigits(cu, lo + (cu[lo] ∈ UInt8.(('-', '+'))), hi)
+
+function Base.tryparse(::Type{X}, s::AbstractString) where {T, f, X <: FixedPoint{T,f}}
+    bitwidth(T) > 64 && return _tryparse_bf(X, s)
+    IT = bitwidth(T) <= 32 ? Int64 : Int128
+    cu = codeunits(s)
+    ncu = lastindex(cu)
+    dot = findfirst(==(UInt8('.')), cu)
+    if isnothing(dot)
+        # plain integer; anything else (exponent, whitespace, …) goes to BigFloat
+        _isdecint(cu, 1, ncu) || return _tryparse_bf(X, s)
+        n = tryparse(IT, s)
+        isnothing(n) && return _tryparse_bf(X, s)
+        n < 0 && T <: Unsigned && return nothing
+        return _try_convert(X, n)
+    end
+    iplo, iphi = 1, dot - 1          # integer part, may carry a sign
+    fplo, fphi = dot + 1, ncu        # fractional part, digits only
+    ipempty = iphi < iplo
+    fpempty = fphi < fplo
+    ipempty && fpempty && return nothing
+    # the fast decimal path requires plain digits on both sides of the dot;
+    # whitespace, exponents and other syntax fall back to BigFloat parsing
+    ipempty || _isdecint(cu, iplo, iphi) || return _tryparse_bf(X, s)
+    fpempty || _alldigits(cu, fplo, fphi) || return _tryparse_bf(X, s)
+    neg = !ipempty && cu[iplo] == UInt8('-')
+    neg && T <: Unsigned && return nothing
+    # trailing fractional zeros leave the value unchanged but enlarge the
+    # denominator, so drop them to keep more inputs on the integer fast path
+    while fphi >= fplo && cu[fphi] == UInt8('0')
+        fphi -= 1
+    end
+    nd = fphi < fplo ? 0 : fphi - fplo + 1
+    ip = ipempty ? zero(IT) : tryparse(IT, SubString(s, 1, dot - 1))
+    fp = nd == 0 ? zero(IT) : tryparse(IT, SubString(s, dot + 1, fphi))
+    (isnothing(ip) || isnothing(fp)) && return _tryparse_bf(X, s)
+    try
+        d = one(IT)
+        for _ in 1:nd
+            d = checked_mul(d, IT(10))
+        end
+        num = checked_add(checked_mul(abs(ip), d), fp)
+        return _try_convert(X, (neg ? -num : num) // d)
+    catch e
+        e isa OverflowError && return _tryparse_bf(X, s)
+        rethrow()
+    end
+end
+
+function _tryparse_bf(::Type{X}, s::AbstractString) where {X <: FixedPoint}
+    r = tryparse(BigFloat, s)
+    isnothing(r) ? nothing : _try_convert(X, r)
+end
+
+function _convert(::Type{X}, x) where {X <: FixedPoint}
+    y = _try_convert(X, x)
+    isnothing(y) ? throw_converterror(X, x) : y
 end
 
 """

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -52,43 +52,43 @@ function _convert(::Type{F}, x::Fixed{T2,f2}) where {T, T2, f, f2, F <: Fixed{T,
     reinterpret(F, _unsafe_trunc(T, y))
 end
 
-function _convert(::Type{F}, x::Integer) where {T, f, F <: Fixed{T,f}}
+function _try_convert(::Type{F}, x::Integer) where {T, f, F <: Fixed{T,f}}
     if ((typemin(T) >> f) <= x) & (x <= (typemax(T) >> f))
         reinterpret(F, _unsafe_trunc(T, x) << f)
     else
-        throw_converterror(F, x)
+        nothing
     end
 end
 
-function _convert(::Type{F}, x::AbstractFloat) where {T, f, F <: Fixed{T,f}}
+function _try_convert(::Type{F}, x::AbstractFloat) where {T, f, F <: Fixed{T,f}}
     bigx = big(x)
     bmin = BigFloat(typemin(F)) - @exp2(-f-1)
     bmax = BigFloat(typemax(F)) + @exp2(-f-1)
     if bmin <= bigx < bmax
         reinterpret(F, round(T, bigx * @exp2(f)))
     else
-        throw_converterror(F, x)
+        nothing
     end
 end
 
 _convert(::Type{F}, x::Float16) where {T, f, F <: Fixed{T,f}} = F(Float32(x))
 
-function _convert(::Type{F}, x::Union{Float32, Float64}) where {T, f, F <: Fixed{T,f}}
+function _try_convert(::Type{F}, x::Union{Float32, Float64}) where {T, f, F <: Fixed{T,f}}
     Tf = typeof(x)
     if Tf(typemin(F) - @exp2(-f-1)) <= x < Tf(typemax(F) + @exp2(-f-1))
         reinterpret(F, round(T, x * @exp2(f)))
     else
-        throw_converterror(F, x)
+        nothing
     end
 end
 
-function _convert(::Type{F}, x::Rational) where {T, f, F <: Fixed{T,f}}
+function _try_convert(::Type{F}, x::Rational) where {T, f, F <: Fixed{T,f}}
     xmin = widemul(denominator(x), widen1(T)(typemin(T)) << 0x1 - 0x1)
     xmax = widemul(denominator(x), oneunit(widen1(T)) << bitwidth(T) - 0x1)
     if xmin <= (widen1(numerator(x)) << UInt8(f + 1)) < xmax
         reinterpret(F, round(T, convert(floattype(T), x) * @exp2(f)))
     else
-        throw_converterror(F, x)
+        nothing
     end
 end
 

--- a/src/normed.jl
+++ b/src/normed.jl
@@ -51,14 +51,14 @@ function _convert(::Type{N}, x::Normed{UInt8,8}) where {N <: Normed{UInt16,16}} 
     reinterpret(N0f16, convert(UInt16, 0x0101*reinterpret(x)))
 end
 
-function _convert(::Type{N}, x::Real) where {T, f, N <: Normed{T,f}}
+function _try_convert(::Type{N}, x::Real) where {T, f, N <: Normed{T,f}}
     if T == UInt128 # for UInt128, we can't widen
         # the upper limit is not exact
-        (0 <= x) & (x <= (typemax(T)/rawone(N))) || throw_converterror(N, x)
+        (0 <= x) & (x <= (typemax(T)/rawone(N))) || return nothing
         y = round(rawone(N)*x)
     else
         y = round(widen1(rawone(N))*x)
-        (0 <= y) & (y <= typemax(T)) || throw_converterror(N, x)
+        (0 <= y) & (y <= typemax(T)) || return nothing
     end
     reinterpret(N, _unsafe_trunc(T, y))
 end
@@ -69,11 +69,11 @@ function _convert(::Type{N}, x::Float16) where {T, f, N <: Normed{T,f}}
     end
     return _convert(N, Float32(x))
 end
-function _convert(::Type{N}, x::Tf) where {T, f, N <: Normed{T,f}, Tf <: Union{Float32, Float64}}
+function _try_convert(::Type{N}, x::Tf) where {T, f, N <: Normed{T,f}, Tf <: Union{Float32, Float64}}
     if T === UInt128 && f == 53
-        0 <= x <= Tf(3.777893186295717e22) || throw_converterror(N, x)
+        0 <= x <= Tf(3.777893186295717e22) || return nothing
     else
-        0 <= x <= Tf((typemax(T)-rawone(N))/rawone(N)+1) || throw_converterror(N, x)
+        0 <= x <= Tf((typemax(T)-rawone(N))/rawone(N)+1) || return nothing
     end
 
     f == 1 && x == Tf(typemax(N)) && return typemax(N)
@@ -100,11 +100,11 @@ function _convert(::Type{N}, x::Tf) where {T, f, N <: Normed{T,f}, Tf <: Union{F
     return reinterpret(N, unsafe_trunc(T, yi >> (ex & bits)))
 end
 
-function _convert(::Type{N}, x::Rational) where {T, f, N <: Normed{T,f}}
+function _try_convert(::Type{N}, x::Rational) where {T, f, N <: Normed{T,f}}
     if 0 <= x <= Rational(typemax(N))
         reinterpret(N, round(T, convert(floattype(T), x) * rawone(N)))
     else
-        throw_converterror(N, x)
+        nothing
     end
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,3 +1,5 @@
+using Random
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     normedtypes = (N0f8, N0f16)                      # precompiled Normed types

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -25,20 +25,8 @@ end
 issue288_out = String(take!(buf))
 
 @testset "issue288" begin
-    expected_issue288 = "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
-    if issue288_in == expected_issue288 # just leave it in the report
-        @test issue288_in == expected_issue288
-    else
-        @test_broken issue288_in == expected_issue288
-        @warn """broken: "$issue288_in"\nexpected: "$expected_issue288" """
-    end
-    expected_issue288 = "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
-    if issue288_out == expected_issue288 # just leave it in the report
-        @test issue288_out == expected_issue288
-    else
-        @test_broken issue288_out == expected_issue288
-        @warn """broken: "$issue288_out"\nexpected: "$expected_issue288" """
-    end
+    @test issue288_in == "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
+    @test issue288_out == "-1.0Q0f7 -1.0Q0f15 -1.0Q0f15 -1.0Q0f7 "
 end
 
 function test_op(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol) where {F,T}

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Statistics, Test
+using FixedPointNumbers, Statistics, Random, StableRNGs, Test
 using FixedPointNumbers: bitwidth
 
 # issue #288
@@ -404,6 +404,8 @@ end
         @test ndims(a) == 2 && eltype(a) == F
         @test size(a) == (3,5)
     end
+    @test !(rand(Q0f15) == rand(Q0f15) == rand(Q0f15)) # If this fails, we should suspect a bug.
+    @test rand(StableRNG(1234), Q0f7) === 0.531Q0f7
 end
 
 @testset "floatmin" begin

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -79,7 +79,11 @@ end
 
 @testset "domain of f" begin
     # TODO: change the upper limit
-    @test_logs (:warn, r"`f=8` with raw type `T=Int8` will be removed") zero(Fixed{Int8,8})
+    if Base.JLOptions().depwarn == 1
+        @test_logs (:warn, r"`f=8` with raw type `T=Int8` will be removed") zero(Fixed{Int8,8})
+    else
+        @test zero(Fixed{Int8,8}) isa Fixed{Int8,8}
+    end
     @test_throws DomainError zero(Fixed{Int8,-1})
     # @test_throws DomainError zero(Fixed{Int8,8})
     @test_throws DomainError zero(Fixed{Int8,9})
@@ -147,6 +151,36 @@ end
     @test_throws ArgumentError convert(Q7f8, Base.TwicePrecision(0x80, 0x01))
     tp = Base.TwicePrecision(0xFFFFFFFFp-32, 0xFFFFFFFEp-64)
     @test convert(Q0f63, tp) === reinterpret(Q0f63, typemax(Int64))
+end
+
+@testset "parse" begin
+    @test parse(Q3f4, "7.92") === 7.9375Q3f4
+    @test parse(Q0f7, "-1.0") === -1.0Q0f7
+    @test tryparse(Q3f4, "7.92") === 7.9375Q3f4
+    @test tryparse(Q3f4, "-3.5") === -3.5Q3f4
+    @test tryparse(Q3f4, "999.0") === nothing
+    @test tryparse(Q3f4, "abc") === nothing
+    @test_throws ArgumentError parse(Q3f4, "abc")
+    @test_throws ArgumentError parse(Q3f4, "999.0")
+
+    # leading/trailing whitespace and exponent notation
+    @test tryparse(Q3f4, " 1.5 ") === 1.5Q3f4
+    @test tryparse(Q3f4, "1e0") === 1.0Q3f4
+    @test tryparse(Q3f4, "1.0e0") === 1.0Q3f4
+    # signs, bare dot positions and malformed input
+    @test tryparse(Q3f4, "+1.5") === 1.5Q3f4
+    @test tryparse(Q3f4, ".5") === 0.5Q3f4
+    @test tryparse(Q3f4, "1.") === 1.0Q3f4
+    @test tryparse(Q3f4, "-.5") === -0.5Q3f4
+    @test tryparse(Q3f4, "") === nothing
+    @test tryparse(Q3f4, ".") === nothing
+    @test tryparse(Q3f4, "1.2.3") === nothing
+    # wide types take the BigFloat path
+    @test tryparse(Fixed{Int128,64}, "0.5") === reinterpret(Fixed{Int128,64}, Int128(1) << 63)
+    # trailing fractional zeros stay on the integer fast path
+    @test tryparse(Q3f4, "0.50000000000000000000") === 0.5Q3f4
+    # a long fractional part with a significant final digit overflows to the BigFloat fallback
+    @test tryparse(Q3f4, "0.50000000000000000001") === 0.5Q3f4
 end
 
 @testset "test_fixed" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Statistics, Test
+using FixedPointNumbers, Statistics, Random, StableRNGs, Test
 using FixedPointNumbers: bitwidth
 
 # issue #288
@@ -595,6 +595,8 @@ end
         @test ndims(a) == 2 && eltype(a) == T
         @test size(a) == (3,5)
     end
+    @test !(rand(N0f16) == rand(N0f16) == rand(N0f16)) # If this fails, we should suspect a bug.
+    @test rand(StableRNG(1234), N0f8) === 0.267N0f8
 end
 
 @testset "Overflow with Float16" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -25,20 +25,8 @@ end
 issue288_out = String(take!(buf))
 
 @testset "issue288" begin
-    expected_issue288 = "1.0N0f8 1.0N0f16 1.0N0f16 1.0N0f8 "
-    if issue288_in == expected_issue288 # just leave it in the report
-        @test issue288_in == expected_issue288
-    else
-        @test_broken issue288_in == expected_issue288
-        @warn """broken: "$issue288_in"\nexpected: "$expected_issue288" """
-    end
-    expected_issue288 = "0.004N0f8 2.0e-5N0f16 2.0e-5N0f16 0.004N0f8 "
-    if issue288_out == expected_issue288 # just leave it in the report
-        @test issue288_out == expected_issue288
-    else
-        @test_broken issue288_out == expected_issue288
-        @warn """broken: "$issue288_out"\nexpected: "$expected_issue288" """
-    end
+    @test issue288_in == "1.0N0f8 1.0N0f16 1.0N0f16 1.0N0f8 "
+    @test issue288_out == "0.004N0f8 2.0e-5N0f16 2.0e-5N0f16 0.004N0f8 "
 end
 
 @testset "domain of f" begin

--- a/test/normed.jl
+++ b/test/normed.jl
@@ -154,6 +154,32 @@ end
     @test_throws InexactError convert(Int8, 256N8f8)
 end
 
+@testset "parse" begin
+    @test parse(N0f8, "0.5") === N0f8(0.5)
+    @test parse(N0f8, "1.0") === 1N0f8
+    @test parse(N0f8, "0.0") === 0N0f8
+    @test tryparse(N0f8, "0.5") === N0f8(0.5)
+    @test tryparse(N0f8, "-0.1") === nothing
+    @test tryparse(N0f8, "1.5") === nothing
+    @test tryparse(N0f8, "abc") === nothing
+    @test_throws ArgumentError parse(N0f8, "-0.1")
+    @test_throws ArgumentError parse(N0f8, "abc")
+
+    # leading/trailing whitespace and exponent notation
+    @test tryparse(N0f8, " 0.5 ") === N0f8(0.5)
+    @test tryparse(N0f8, "1e0") === 1N0f8
+    @test tryparse(N0f8, "0.5e0") === N0f8(0.5)
+    # signs, bare dot positions and malformed input
+    @test tryparse(N0f8, "+0.5") === N0f8(0.5)
+    @test tryparse(N0f8, ".5") === N0f8(0.5)
+    @test tryparse(N0f8, "-1") === nothing
+    @test tryparse(N0f8, "") === nothing
+    @test tryparse(N0f8, ".") === nothing
+    @test tryparse(N0f8, "0.5.0") === nothing
+    # wide types take the BigFloat path
+    @test tryparse(Normed{UInt128,128}, "0.5") === reinterpret(Normed{UInt128,128}, typemax(UInt128) ÷ 2 + 1)
+end
+
 @testset "rational conversions" begin
     @test convert(Rational, 0.5N0f8) === Rational{UInt8}(0x80//0xff)
     @test convert(Rational, 0.5N4f12) === Rational{UInt16}(0x800//0xfff)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,11 @@
 using FixedPointNumbers, Test
+using JET
 
 @test isempty(detect_ambiguities(FixedPointNumbers, Base, Core))
+
+@testset "JET" begin
+    JET.test_package(FixedPointNumbers; target_modules=(FixedPointNumbers,))
+end
 
 @testset "normed" begin
     include("normed.jl")


### PR DESCRIPTION
Support `Base.parse` and `Base.tryparse` for `Normed` and `Fixed`.

The PR builds on #324 and targets FixedPointNumbers.jl in v0.8.